### PR TITLE
Fix: Terraform in sub directories did not work properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/bmatcuk/doublestar v1.2.2
 	github.com/hashicorp/hcl/v2 v2.3.0
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2


### PR DESCRIPTION
1. `filepath.Walk` did not follow symlinks. Now using glob from the [`doublestar`](https://github.com/bmatcuk/doublestar) package to find all `.tf` files, which works with symlinks as well.
2. Dir parameter flag always got overwritten with default `.`. Now it doesn't.