### PR TITLE
Use local Terraform variable for safer merging

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func tagFileResources(path string, dir string, tags string, tfVersion int) {
 
 	_, filename := filepath.Split(path)
 	filename = strings.TrimSuffix(filename, filepath.Ext(path))
+	filename = strings.ReplaceAll(filename, ".", "-")
 
 	file, diagnostics := hclwrite.ParseConfig(src, path, hcl.InitialPos)
 	if diagnostics.HasErrors() {


### PR DESCRIPTION
## Summary
This PR introduces a different approach to merging existing tags.  
Instead of trying to `merge()` existing and added tags inline, it **moves** the existing tags to a local variable, does the same of the added tags, and finally merges by referring these two local variables.  
This approach fixes several issues found the previous approach, as well as enhancements to properly support all kinds of syntax:  
- Added support for Terraform 11 `tags` **blocks**: Terraform 11 had supported both `tags {}` (block) and `tags = {}` (attribute). Terratag now supports both as well.  
- Previous code had split inline maps by itself, which had meant no support for cases where map items are **not** separated by comma but by line breaks instead. Now we don't have to parse those map, but instead have `hclwrite` move them over to the local block, so we support every kind of map syntax HCL does
- Reduced Terraform 11/12 forks in code: there's a fork with only a [single and simple line](https://github.com/env0/terratag/blob/0022dac89ee194f05470958f46bd663e9d986e9f/main.go#L198) of code that separates between 11 and 12 tags

## Samples
These should all be part of our test suite of course. But just so you can get some sense of how it looks like:

### Terraform 11 blocks
Input:
```terraform
resource "aws_s3_bucket" "website_bucket" {
  tags: {
    foo = "bar"
  }
}
```
Output:
```terraform
resource "aws_s3_bucket" "website_bucket" {
  tags = "${merge(local.terratag_found_s3__aws_s3_bucket__website_bucket, local.terratag_added_s3)}"
}

locals {
  terratag_found_s3__aws_s3_bucket__website_bucket = {
    # Note: since locals are actually local variables in modules, not files, I had to include the file name too
    foo = "bar"
  }
  terratag_added_s3 = {env0_environment_id="hoorah"}
}
```

### Terraform 11 attribute mixing commas and line breaks
Input:
```terraform
resource "aws_s3_bucket" "website_bucket" {
  tags: {
    foo = "bar"
  }
}
```
Output:
```terraform
resource "aws_s3_bucket" "website_bucket" {
  tags = "${merge(local.terratag_found_s3__aws_s3_bucket__website_bucket, local.terratag_added_s3)}"
}

locals {
  terratag_found_s3__aws_s3_bucket__website_bucket = {
    foo   = "bar", boo = "far" # note there is just one comma
    zoo   = "loo"              # note there is no comma
    hello = "there"
  }
  terratag_added_s3 = {env0_environment_id="hoorah"}
}
```

### Terraform 11 variables, functions and locals
Input:
```terraform
resource "aws_s3_bucket" "website_bucket" {
  tags = "${merge(local.my.own, map("hello", "world"))}"  # using functions and other variables
}
locals {
  # note a preexisting local block will remain. tf is cool with that
  my = {
    own = {
      hey = "there"
    }
  }
}
```
Output:
```terraform
resource "aws_s3_bucket" "website_bucket" {
  tags = "${merge(local.terratag_found_s3__aws_s3_bucket__website_bucket, local.terratag_added_s3)}"
}

locals {
  # note a preexisting local block will remain. tf is cool with that
  my = {
    own = {
      hey = "there"
    }
  }
}
locals {
  terratag_found_s3__aws_s3_bucket__website_bucket = "${merge(local.my.own, map("hello", "world"))}"
  terratag_added_s3                                = {env0_environment_id="hoorah"}
}
```

### Terraform 12
Input:
```hcl
resource "aws_s3_bucket" "website_bucket" {
  tags = "merge(local.my.own, map("hello", "world"))"  # using functions and other variables
}
locals {
  # note a preexisting local block will remain. tf is cool with that
  my = {
    own = {
      hey = "there"
    }
  }
}
```
Output:
```terraform
resource "aws_s3_bucket" "website_bucket" {
  tags = merge(local.terratag_found_s3__aws_s3_bucket__website_bucket, local.terratag_added_s3)
}

locals {
  # note a preexisting local block will remain. tf is cool with that
  my = {
    own = {
      hey = "there"
    }
  }
}
locals {
  terratag_found_s3__aws_s3_bucket__website_bucket = merge(local.my.own, map("hello", "world"))
  terratag_added_s3                                = {env0_environment_id="hoorah"}
}
```