### PR TITLE
Fix: Tags are added to non-aws resources with 'tag' attribute

### DIFF
--- a/tfschema/tfschema.go
+++ b/tfschema/tfschema.go
@@ -5,36 +5,39 @@ import (
 	"github.com/env0/terratag/errors"
 	"github.com/mitchellh/mapstructure"
 	"os/exec"
+	"strings"
 )
 
 func IsTaggable(dir string, resourceType string) (bool, bool) {
-	command := exec.Command("tfschema", "resource", "show", "-format=json", resourceType)
-	command.Dir = dir
-	output, err := command.Output()
-	outputAsString := string(output)
-	errors.PanicOnError(err, &outputAsString)
-
-	var schema map[string]interface{}
-
-	err = json.Unmarshal(output, &schema)
-	errors.PanicOnError(err, nil)
-
 	isTaggable := false
 	isTaggableViaSpecialTagBlock := false
 
-	attributes := schema["attributes"].([]interface{})
-	for _, attributeMap := range attributes {
-		var attribute TfSchemaAttribute
-		err := mapstructure.Decode(attributeMap, &attribute)
+	if strings.HasPrefix(resourceType, "aws_") {
+		command := exec.Command("tfschema", "resource", "show", "-format=json", resourceType)
+		command.Dir = dir
+		output, err := command.Output()
+		outputAsString := string(output)
+		errors.PanicOnError(err, &outputAsString)
+
+		var schema map[string]interface{}
+
+		err = json.Unmarshal(output, &schema)
 		errors.PanicOnError(err, nil)
 
-		if attribute.Name == "tags" {
-			isTaggable = true
-		}
-	}
+		attributes := schema["attributes"].([]interface{})
+		for _, attributeMap := range attributes {
+			var attribute TfSchemaAttribute
+			err := mapstructure.Decode(attributeMap, &attribute)
+			errors.PanicOnError(err, nil)
 
-	if resourceType == "aws_autoscaling_group" {
-		isTaggableViaSpecialTagBlock = true
+			if attribute.Name == "tags" {
+				isTaggable = true
+			}
+		}
+
+		if resourceType == "aws_autoscaling_group" {
+			isTaggableViaSpecialTagBlock = true
+		}
 	}
 
 	return isTaggable, isTaggableViaSpecialTagBlock


### PR DESCRIPTION
Terratag doesn't support any other cloud providers yet.  
Fixes #14  