### PR TITLE
Support azurerm and azurestack providers

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -12,6 +12,8 @@ func getProviderByResource(resource hclwrite.Block) Provider {
 		return "aws"
 	} else if strings.HasPrefix(resourceType, "google_") {
 		return "gcp"
+	} else if strings.HasPrefix(resourceType, "azurerm_") || strings.HasPrefix(resourceType, "azurestack_") {
+		return "azure"
 	}
 
 	return ""
@@ -21,7 +23,7 @@ func IsTaggableByAttribute(resource hclwrite.Block, attribute string) bool {
 	provider := getProviderByResource(resource)
 	tagBlockId := GetTagBlockIdByResource(resource)
 
-	if (provider == "aws" || provider == "gcp") && attribute == tagBlockId {
+	if (provider != "") && attribute == tagBlockId {
 		return true
 	}
 	return false
@@ -30,7 +32,7 @@ func IsTaggableByAttribute(resource hclwrite.Block, attribute string) bool {
 func GetTagBlockIdByResource(resource hclwrite.Block) string {
 	provider := getProviderByResource(resource)
 
-	if provider == "aws" {
+	if provider == "aws" || provider == "azure" {
 		return "tags"
 	} else if provider == "gcp" {
 		return "labels"
@@ -48,6 +50,8 @@ func isSupportedProvider(provider Provider) bool {
 	case "aws":
 		return true
 	case "gcp":
+		return true
+	case "azure":
 		return true
 	default:
 		return false


### PR DESCRIPTION
# Support `azurerm` and `azurestack` providers

## Test Cases
### Input
<details>
  <summary>azurerm.tf</summary>

  ```tf
  # azurerm.tf
  
  provider "azurerm" {
  Provider
  version = "=2.0.0"
  features {}
  }
  
  resource "azurerm_resource_group" "example" {
  name     = "example-resources"
  location = "West Europe"
  tags = {
  "oh" = "my"
  }
  }
  
  resource "azurerm_virtual_network" "example" {
  name                = "example-network"
  resource_group_name = azurerm_resource_group.example.name
  location            = azurerm_resource_group.example.location
  address_space       = ["10.0.0.0/16"]
  }
  ```
</details>

<details>
  <summary>azurestack.tf</summary>

```tf
# azurestack.tf

provider "azurestack" {
}

resource "azurestack_resource_group" "test" {
  name     = "production"
  location = "West US"
}

resource "azurestack_virtual_network" "test" {
  name                = "production-network"
  address_space       = ["10.0.0.0/16"]
  location            = "${azurestack_resource_group.test.location}"
  resource_group_name = "${azurestack_resource_group.test.name}"

}

resource "azurestack_virtual_network" "test2" {
  name                = "production-network"
  address_space       = ["10.0.0.0/16"]
  location            = "${azurestack_resource_group.test.location}"
  resource_group_name = "${azurestack_resource_group.test.name}"
  tags = {
    "yo" = "ho"
  }
}
```
</details>

```
terratag on  master [$✘!+?] via 🐹 v1.13.5 took 3s 
➜ go run . -tags='{"env0_environment_id":"40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id":"43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}' -dir=. -skipTerratagFiles=true
```

### Output

<details>
  <summary>azurerm.terratag.tf</summary>

  ```tf
# azurerm.terratag.tf

provider "azurerm" {
Provider
  version = "=2.0.0"
  features {}
}

resource "azurerm_resource_group" "example" {
  name     = "example-resources"
  location = "West Europe"
  tags     = merge( map("oh" , "my"), local.terratag_added_azurerm)
}

resource "azurerm_virtual_network" "example" {
  name                = "example-network"
  resource_group_name = azurerm_resource_group.example.name
  location            = azurerm_resource_group.example.location
  address_space       = ["10.0.0.0/16"]
  tags                = local.terratag_added_azurerm
}
locals {
  terratag_added_azurerm = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
}

  ```
</details>

<details>
  <summary>azurestack.terratag.tf</summary>

```tf
# azurestack.terratag.tf

provider "azurestack" {

}

resource "azurestack_resource_group" "test" {
  name     = "production"
  location = "West US"
  tags     = local.terratag_added_azurestack
}

resource "azurestack_virtual_network" "test" {
  name                = "production-network"
  address_space       = ["10.0.0.0/16"]
  location            = "${azurestack_resource_group.test.location}"
  resource_group_name = "${azurestack_resource_group.test.name}"

  tags = local.terratag_added_azurestack
}

resource "azurestack_virtual_network" "test2" {
  name                = "production-network"
  address_space       = ["10.0.0.0/16"]
  location            = "${azurestack_resource_group.test.location}"
  resource_group_name = "${azurestack_resource_group.test.name}"
  tags                = merge( map("yo" , "ho"), local.terratag_added_azurestack)

}
locals {
  terratag_added_azurestack = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
}
```
</details>

```bash
➜ terraform validate 

Success! The configuration is valid,
```

> **NOTE:** `azuread` provider resources isn't listed as supported because it's only resource that supports tags is [azuread_service_principal](https://www.terraform.io/docs/providers/azuread/r/service_principal.html), but those are of different structure and serve a different purpose