### PR TITLE
Fix: TF12 local submodules tagging

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	tags, dir, isSkipTerratagFiles, isMissingArg := InitArgs()
 
-	tfVersion := GetTeraformVersion()
+	tfVersion := GetTerraformVersion()
 
 	if isMissingArg || !isTerraformInitRun(dir) {
 		return

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/thoas/go-funk"
 	"github.com/zclconf/go-cty/cty"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -24,11 +25,28 @@ func main() {
 
 	tfVersion := GetTeraformVersion()
 
-	if isMissingArg {
+	if isMissingArg || !isTerraformInitRun(dir) {
+		log.Print("Exiting...")
 		return
 	}
 
 	tagDirectoryResources(dir, tags, isSkipTerratagFiles, tfVersion)
+}
+
+func isTerraformInitRun(dir string) bool {
+	_, err := os.Stat(dir + "/.terraform")
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Print("terraform init must run before running terratag")
+			return false
+		}
+
+		message := "couldn't determine if terraform init has run"
+		PanicOnError(err, &message)
+	}
+
+	return true
 }
 
 func tagDirectoryResources(dir string, tags string, isSkipTerratagFiles bool, tfVersion int) {

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 	"log"
-	"os"
 	"strings"
 )
 
@@ -22,29 +21,13 @@ func main() {
 
 	tfVersion := GetTerraformVersion()
 
-	if isMissingArg || !isTerraformInitRun(dir) {
+	if isMissingArg || !IsTerraformInitRun(dir) {
 		return
 	}
 
 	matches := GetTerraformFilePaths(dir)
 
 	tagDirectoryResources(dir, matches, tags, isSkipTerratagFiles, tfVersion)
-}
-
-func isTerraformInitRun(dir string) bool {
-	_, err := os.Stat(dir + "/.terraform")
-
-	if err != nil {
-		if os.IsNotExist(err) {
-			log.Fatalln("terraform init must run before running terratag")
-			return false
-		}
-
-		message := "couldn't determine if terraform init has run"
-		PanicOnError(err, &message)
-	}
-
-	return true
 }
 
 func tagDirectoryResources(dir string, matches []string, tags string, isSkipTerratagFiles bool, tfVersion int) {

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -76,9 +76,6 @@ func getTerraformModulesDirPaths(dir string) []string {
 	jsonFile, err := os.Open(dir + "/.terraform/modules/modules.json")
 
 	if os.IsNotExist(err) {
-		closeErr := jsonFile.Close()
-		errors.PanicOnError(closeErr, nil)
-
 		return paths
 	}
 	errors.PanicOnError(err, nil)

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -1,9 +1,15 @@
 package terraform
 
 import (
+	"encoding/json"
+	"github.com/bmatcuk/doublestar"
 	"github.com/env0/terratag/errors"
+	"github.com/thoas/go-funk"
+	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -20,4 +26,70 @@ func GetTeraformVersion() int {
 
 	log.Fatalln("Terratag only supports Terraform 0.11.x and 0.12.x - your version says ", outputAsString)
 	return -1
+}
+
+func GetTerraformFilePaths(rootDir string) []string {
+	const tfFileMatcher = "/**/*.tf"
+
+	tfFiles, err := doublestar.Glob(rootDir + tfFileMatcher)
+	errors.PanicOnError(err, nil)
+
+	modulesDirs := getTerraformModulesDirPaths(rootDir)
+
+	for _, moduleDir := range modulesDirs {
+		matches, err := doublestar.Glob(moduleDir + tfFileMatcher)
+		errors.PanicOnError(err, nil)
+
+		tfFiles = append(tfFiles, matches...)
+	}
+
+	for i, tfFile := range tfFiles {
+		resolvedTfFile, err := filepath.EvalSymlinks(tfFile)
+		errors.PanicOnError(err, nil)
+
+		tfFiles[i] = resolvedTfFile
+	}
+
+	return funk.UniqString(tfFiles)
+}
+
+func getTerraformModulesDirPaths(dir string) []string {
+	var paths []string
+	var modulesJson ModulesJson
+
+	jsonFile, err := os.Open(dir + "/.terraform/modules/modules.json")
+
+	if os.IsNotExist(err) {
+		closeErr := jsonFile.Close()
+		errors.PanicOnError(closeErr, nil)
+
+		return paths
+	}
+	errors.PanicOnError(err, nil)
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	err = json.Unmarshal(byteValue, &modulesJson)
+	errors.PanicOnError(err, nil)
+
+	for _, module := range modulesJson.Modules {
+		modulePath, err := filepath.EvalSymlinks(dir + "/" + module.Dir)
+		errors.PanicOnError(err, nil)
+
+		paths = append(paths, modulePath)
+	}
+
+	err = jsonFile.Close()
+	errors.PanicOnError(err, nil)
+
+	return paths
+}
+
+type ModulesJson struct {
+	Modules []ModuleMetadata `json:"Modules"`
+}
+
+type ModuleMetadata struct {
+	Key    string `json:"Key"`
+	Source string `json:"Source"`
+	Dir    string `json:"Dir"`
 }

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -28,6 +28,22 @@ func GetTerraformVersion() int {
 	return -1
 }
 
+func IsTerraformInitRun(dir string) bool {
+	_, err := os.Stat(dir + "/.terraform")
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Fatalln("terraform init must run before running terratag")
+			return false
+		}
+
+		message := "couldn't determine if terraform init has run"
+		errors.PanicOnError(err, &message)
+	}
+
+	return true
+}
+
 func GetTerraformFilePaths(rootDir string) []string {
 	const tfFileMatcher = "/**/*.tf"
 

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-func GetTeraformVersion() int {
+func GetTerraformVersion() int {
 	output, err := exec.Command("terraform", "version").Output()
 	outputAsString := strings.TrimSpace(string(output))
 	errors.PanicOnError(err, &outputAsString)


### PR DESCRIPTION
Fixes #20 

### Solution
These are the steps that terratag will take in order to find all relevant `.tf` files:
1. Recursively searches for any `.tf` file under the root folder (same behavior as today)
2. Parses the `modules.json` file (if exists) under `.terraform/modules` to find relevant local submodules directories that aren't under the root folder.
3. Recursively  searches for any `.tf` files under **each** directory found in step 2.
4. Combine all `.tf` files found into a single slice and exclude duplicates.

This logic will comply both for TF11 and TF12, so there's no need for special flags in code 🥇 