### PR TITLE
Fix: unquouted tag keys creates malformed HCL

### DIFF
--- a/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
@@ -7,7 +7,11 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name"        , "My bucket"), local.terratag_added_main)}"
+  tags = "${merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    "${max(1, 2)}"            , "Test function" ,    "${local.localTagKey}"    , "Test expression"), local.terratag_added_main)}"
+}
+
+locals {
+  localTagKey = "localTagKey"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/aws_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.tf.bak
@@ -8,6 +8,16 @@ resource "aws_s3_bucket" "b" {
   acl    = "private"
 
   tags = {
-    "Name"        = "My bucket"
+    "Name"                    = "My bucket"
+    Unquoted1                 = "I wanna be quoted"
+    "AnotherName"             = "Yo"
+    Unquoted2                 = "I really wanna be quoted"
+    Unquoted3                 = "I really really wanna be quoted and I got a comma",
+    "${max(1, 2)}"            = "Test function"
+    "${local.localTagKey}"    = "Test expression"
   }
+}
+
+locals {
+  localTagKey = "localTagKey"
 }

--- a/test/fixture/terraform_11/aws_tags_map/input/main.tf
+++ b/test/fixture/terraform_11/aws_tags_map/input/main.tf
@@ -8,6 +8,16 @@ resource "aws_s3_bucket" "b" {
   acl    = "private"
 
   tags = {
-    "Name"        = "My bucket"
+    "Name"                    = "My bucket"
+    Unquoted1                 = "I wanna be quoted"
+    "AnotherName"             = "Yo"
+    Unquoted2                 = "I really wanna be quoted"
+    Unquoted3                 = "I really really wanna be quoted and I got a comma",
+    "${max(1, 2)}"            = "Test function"
+    "${local.localTagKey}"    = "Test expression"
   }
+}
+
+locals {
+  localTagKey = "localTagKey"
 }

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
@@ -7,7 +7,11 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name"        , "My bucket"), local.terratag_added_main)
+  tags = merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    join("-", ["foo", "bar"]) , "Test function" ,    (local.localTagKey)       , "Test expression"), local.terratag_added_main)
+}
+
+locals {
+  localTagKey = "localTagKey"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.tf.bak
@@ -8,6 +8,16 @@ resource "aws_s3_bucket" "b" {
   acl    = "private"
 
   tags = {
-    "Name"        = "My bucket"
+    "Name"                    = "My bucket"
+    Unquoted1                 = "I wanna be quoted"
+    "AnotherName"             = "Yo"
+    Unquoted2                 = "I really wanna be quoted"
+    Unquoted3                 = "I really really wanna be quoted and I got a comma",
+    join("-", ["foo", "bar"]) = "Test function"
+    (local.localTagKey)       = "Test expression"
   }
+}
+
+locals {
+  localTagKey = "localTagKey"
 }

--- a/test/fixture/terraform_12/aws_tags_map/input/main.tf
+++ b/test/fixture/terraform_12/aws_tags_map/input/main.tf
@@ -8,6 +8,16 @@ resource "aws_s3_bucket" "b" {
   acl    = "private"
 
   tags = {
-    "Name"        = "My bucket"
+    "Name"                    = "My bucket"
+    Unquoted1                 = "I wanna be quoted"
+    "AnotherName"             = "Yo"
+    Unquoted2                 = "I really wanna be quoted"
+    Unquoted3                 = "I really really wanna be quoted and I got a comma",
+    join("-", ["foo", "bar"]) = "Test function"
+    (local.localTagKey)       = "Test expression"
   }
+}
+
+locals {
+  localTagKey = "localTagKey"
 }


### PR DESCRIPTION
Fixes #10

## Solution
Iterate through `Attribute`'s tokens and wrap the relevant `TokenIdent` (that represents the unquoted key) with a starting `TokenOQuote` and a trailing `TokenCQuote`.