### PR TITLE
Fix: bad quoting of key/value attribute string that include variables

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -111,11 +111,14 @@ func AppendTagBlocks(resource *hclwrite.Block, tags string) {
 
 func UnquoteTagsAttribute(swappedTagsStrings []string, text string) string {
 	for _, swappedTagString := range swappedTagsStrings {
+		// treat quotes
 		escapedByWriter := strings.ReplaceAll(swappedTagString, "\"", "\\\"")
 
-		if strings.HasPrefix(swappedTagString, "${") && strings.HasSuffix(swappedTagString, "}") {
-			escapedByWriter = strings.ReplaceAll(escapedByWriter, "${", "$${")
-		} else {
+		// treat variables
+		escapedByWriter = strings.ReplaceAll(escapedByWriter, "${", "$${")
+
+		// add quotes if string isn't wrapped with ${}
+		if !(strings.HasPrefix(swappedTagString, "${") && strings.HasSuffix(swappedTagString, "}")) {
 			escapedByWriter = "\"" + escapedByWriter + "\""
 		}
 

--- a/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
@@ -7,11 +7,12 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    "${max(1, 2)}"            , "Test function" ,    "${local.localTagKey}"    , "Test expression"), local.terratag_added_main)}"
+  tags = "${merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    "${max(1, 2)}"            , "Test function" ,    "${local.localTagKey}"    , "Test expression" ,    "${local.localTagKey2}"   , "Test variable as key" ,    "Yo-${local.localTagKey}" , "Test variable inside key" ,    "Test variable as value" , "${local.localTagKey}" ,    "Test variable inside value"  , "Yo-${local.localTagKey}"), local.terratag_added_main)}"
 }
 
 locals {
-  localTagKey = "localTagKey"
+  localTagKey  = "localTagKey"
+  localTagKey2 = "localTagKey2"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/aws_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.tf.bak
@@ -15,9 +15,14 @@ resource "aws_s3_bucket" "b" {
     Unquoted3                 = "I really really wanna be quoted and I got a comma",
     "${max(1, 2)}"            = "Test function"
     "${local.localTagKey}"    = "Test expression"
+    "${local.localTagKey2}"   = "Test variable as key"
+    "Yo-${local.localTagKey}" = "Test variable inside key"
+    "Test variable as value" = "${local.localTagKey}"
+    "Test variable inside value"  = "Yo-${local.localTagKey}"
   }
 }
 
 locals {
   localTagKey = "localTagKey"
+  localTagKey2 = "localTagKey2"
 }

--- a/test/fixture/terraform_11/aws_tags_map/input/main.tf
+++ b/test/fixture/terraform_11/aws_tags_map/input/main.tf
@@ -15,9 +15,14 @@ resource "aws_s3_bucket" "b" {
     Unquoted3                 = "I really really wanna be quoted and I got a comma",
     "${max(1, 2)}"            = "Test function"
     "${local.localTagKey}"    = "Test expression"
+    "${local.localTagKey2}"   = "Test variable as key"
+    "Yo-${local.localTagKey}" = "Test variable inside key"
+    "Test variable as value" = "${local.localTagKey}"
+    "Test variable inside value"  = "Yo-${local.localTagKey}"
   }
 }
 
 locals {
   localTagKey = "localTagKey"
+  localTagKey2 = "localTagKey2"
 }

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
@@ -7,11 +7,12 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    join("-", ["foo", "bar"]) , "Test function" ,    (local.localTagKey)       , "Test expression"), local.terratag_added_main)
+  tags = merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    join("-", ["foo", "bar"]) , "Test function" ,    (local.localTagKey)       , "Test expression" ,    "${local.localTagKey2}"   , "Test variable as key" ,    "Yo-${local.localTagKey}" , "Test variable inside key" ,    "Test variable as value" , "${local.localTagKey}" ,    "Test variable inside value"  , "Yo-${local.localTagKey}"), local.terratag_added_main)
 }
 
 locals {
-  localTagKey = "localTagKey"
+  localTagKey  = "localTagKey"
+  localTagKey2 = "localTagKey2"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.tf.bak
@@ -15,9 +15,14 @@ resource "aws_s3_bucket" "b" {
     Unquoted3                 = "I really really wanna be quoted and I got a comma",
     join("-", ["foo", "bar"]) = "Test function"
     (local.localTagKey)       = "Test expression"
+    "${local.localTagKey2}"   = "Test variable as key"
+    "Yo-${local.localTagKey}" = "Test variable inside key"
+    "Test variable as value" = "${local.localTagKey}"
+    "Test variable inside value"  = "Yo-${local.localTagKey}"
   }
 }
 
 locals {
   localTagKey = "localTagKey"
+  localTagKey2 = "localTagKey2"
 }

--- a/test/fixture/terraform_12/aws_tags_map/input/main.tf
+++ b/test/fixture/terraform_12/aws_tags_map/input/main.tf
@@ -15,9 +15,14 @@ resource "aws_s3_bucket" "b" {
     Unquoted3                 = "I really really wanna be quoted and I got a comma",
     join("-", ["foo", "bar"]) = "Test function"
     (local.localTagKey)       = "Test expression"
+    "${local.localTagKey2}"   = "Test variable as key"
+    "Yo-${local.localTagKey}" = "Test variable inside key"
+    "Test variable as value" = "${local.localTagKey}"
+    "Test variable inside value"  = "Yo-${local.localTagKey}"
   }
 }
 
 locals {
   localTagKey = "localTagKey"
+  localTagKey2 = "localTagKey2"
 }


### PR DESCRIPTION
Fixes #27 

## Root Cause
We haven't escaped the `$` sign so the `UnquoteTagsAttribute` function did not replace the string as should eventually.

## Solution
Escape it 😅 