### PR TITLE
Fix: quote attribute keys should skip non hcl maps

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -178,6 +178,11 @@ func quoteAttributeKeys(tagsAttribute *hclwrite.Attribute) hclwrite.Tokens {
 	var newTags hclwrite.Tokens
 	tags := tagsAttribute.Expr().BuildTokens(hclwrite.Tokens{})
 
+	// if attribute is a variable
+	if !(isHclMap(tags)) {
+		return tags
+	}
+
 	for i, token := range tags {
 		if isTagKeyUnquoted(tags, i) {
 			openQuote := &hclwrite.Token{

--- a/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
@@ -10,9 +10,20 @@ resource "aws_s3_bucket" "b" {
   tags = "${merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    "${max(1, 2)}"            , "Test function" ,    "${local.localTagKey}"    , "Test expression" ,    "${local.localTagKey2}"   , "Test variable as key" ,    "Yo-${local.localTagKey}" , "Test variable inside key" ,    "Test variable as value" , "${local.localTagKey}" ,    "Test variable inside value"  , "Yo-${local.localTagKey}"), local.terratag_added_main)}"
 }
 
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = "${merge( "${local.localMap}", local.terratag_added_main)}"
+}
+
+
 locals {
   localTagKey  = "localTagKey"
   localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/aws_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.tf.bak
@@ -22,7 +22,18 @@ resource "aws_s3_bucket" "b" {
   }
 }
 
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = "${local.localMap}"
+}
+
+
 locals {
   localTagKey = "localTagKey"
   localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
 }

--- a/test/fixture/terraform_11/aws_tags_map/input/main.tf
+++ b/test/fixture/terraform_11/aws_tags_map/input/main.tf
@@ -22,7 +22,18 @@ resource "aws_s3_bucket" "b" {
   }
 }
 
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = "${local.localMap}"
+}
+
+
 locals {
   localTagKey = "localTagKey"
   localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
 }

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
@@ -10,9 +10,19 @@ resource "aws_s3_bucket" "b" {
   tags = merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    join("-", ["foo", "bar"]) , "Test function" ,    (local.localTagKey)       , "Test expression" ,    "${local.localTagKey2}"   , "Test variable as key" ,    "Yo-${local.localTagKey}" , "Test variable inside key" ,    "Test variable as value" , "${local.localTagKey}" ,    "Test variable inside value"  , "Yo-${local.localTagKey}"), local.terratag_added_main)
 }
 
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge( local.localMap, local.terratag_added_main)
+}
+
 locals {
   localTagKey  = "localTagKey"
   localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.tf.bak
@@ -22,7 +22,17 @@ resource "aws_s3_bucket" "b" {
   }
 }
 
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = local.localMap
+}
+
 locals {
   localTagKey = "localTagKey"
   localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
 }

--- a/test/fixture/terraform_12/aws_tags_map/input/main.tf
+++ b/test/fixture/terraform_12/aws_tags_map/input/main.tf
@@ -22,7 +22,17 @@ resource "aws_s3_bucket" "b" {
   }
 }
 
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = local.localMap
+}
+
 locals {
   localTagKey = "localTagKey"
   localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
 }


### PR DESCRIPTION
### Issue
When #26 was merged, I haven't covered the scenario where tag attribute is a variables, like:
```terraform
tags = local.something
```
so the previous fix (quoting map keys) parsed the variable in a wrong way and had a panic:
```bash
2020/06/10 14:14:18 Preexisting tags ATTRIBUTE found on resource. Merging.
panic: runtime error: index out of range [3] with length 3

goroutine 1 [running]:
github.com/env0/terratag/convert.isTagKeyUnquoted(...)
        /Users/yaronyarimi/dev/terratag/convert/convert.go:174
github.com/env0/terratag/convert.quoteAttributeKeys(0xc000098cf0, 0x1, 0x1, 0xc000098cf0)
        /Users/yaronyarimi/dev/terratag/convert/convert.go:182 +0x3a3
github.com/env0/terratag/convert.MoveExistingTags(0xc00009c16f, 0x4, 0xc000099d40, 0xc00009c2e0, 0x11, 0xc0000e8200, 0xd)
        /Users/yaronyarimi/dev/terratag/convert/convert.go:141 +0x3e4
main.tagResource(0xc00009c16f, 0x4, 0xc000099d40, 0xc00009c2e0, 0x11, 0xc0000e8200, 0xb, 0x0, 0xc000099020)
        /Users/yaronyarimi/dev/terratag/main.go:101 +0xd0
main.tagFileResources(0xc00009c160, 0x16, 0x7ffeefbff8b0, 0xe, 0x7ffeefbff8c5, 0x14, 0xb)
        /Users/yaronyarimi/dev/terratag/main.go:73 +0x498
main.tagDirectoryResources(0x7ffeefbff8b0, 0xe, 0xc0000ac020, 0x1, 0x1, 0x7ffeefbff8c5, 0x14, 0x1499d01, 0xb)
        /Users/yaronyarimi/dev/terratag/main.go:43 +0x1b1
main.Terratag()
        /Users/yaronyarimi/dev/terratag/main.go:35 +0xe6
main.main()
        /Users/yaronyarimi/dev/terratag/main.go:21 +0x20
```

### Solution
We should skip quoting map keys when value is not an HCL map