### PR TITLE
Chore: Use tfschema 0.5.0 instead of fork, send RootDir via options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/bmatcuk/doublestar v1.2.2
 	github.com/hashicorp/hcl/v2 v2.6.0
-	github.com/minamijoyo/tfschema v0.4.1
+	github.com/minamijoyo/tfschema v0.5.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/gomega v1.10.1
 	github.com/otiai10/copy v1.2.0
@@ -14,5 +14,3 @@ require (
 	golang.org/x/sys v0.0.0-20200523222454-059865788121 // indirect
 	google.golang.org/protobuf v1.24.0 // indirect
 )
-
-replace github.com/minamijoyo/tfschema => github.com/env0/tfschema v0.4.2-0.20200831150439-495c3db8e4bd

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,8 @@ github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00v
 github.com/miekg/dns v1.0.8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/minamijoyo/tfschema v0.3.0 h1:t1uxZOguW6fEruITbQ2vVUJc/ImvPiBvK+9qzYF1fo4=
 github.com/minamijoyo/tfschema v0.3.0/go.mod h1:h+LWOkqHrQKrTit+3QWkhmhXqhinq/IQJ0EfcrxYg3A=
+github.com/minamijoyo/tfschema v0.5.0 h1:wFREazT1m1c27ZOzkI/0Sj0RCqni+bl29rozYIZ604A=
+github.com/minamijoyo/tfschema v0.5.0/go.mod h1:rL/i9z2yOadXs74KcZay3wuD0l4d8ShbQpC7uAuFOS4=
 github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=

--- a/tfschema/tfschema.go
+++ b/tfschema/tfschema.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/minamijoyo/tfschema/tfschema"
 	"log"
-	"os"
 	"strings"
 )
 
@@ -20,7 +19,9 @@ func IsTaggable(dir string, resource hclwrite.Block) bool {
 	if providers.IsSupportedResource(resourceType) {
 		providerName, _ := detectProviderName(resourceType)
 
-		client := getTerraformSchemaClient(dir, providerName)
+		client, err := tfschema.NewClient(providerName, tfschema.Option{RootDir: dir})
+		errors.PanicOnError(err, nil)
+
 		typeSchema, err := client.GetResourceTypeSchema(resourceType)
 		if err != nil {
 			if strings.Contains(err.Error(), "Failed to find resource type") {
@@ -60,12 +61,4 @@ func detectProviderName(name string) (string, error) {
 		return "", fmt.Errorf("Failed to detect a provider name: %s", name)
 	}
 	return s[0], nil
-}
-
-func getTerraformSchemaClient(dir string, providerName string) tfschema.Client {
-	err := os.Setenv("TFSCHEMA_ROOT_DIRECTORY", dir)
-	errors.PanicOnError(err, nil)
-	client, err := tfschema.NewClient(providerName)
-	errors.PanicOnError(err, nil)
-	return client
 }


### PR DESCRIPTION
Use `tfschema` new release 0.5.0, which supports sending the RootDir via an argument to `NewClient`. Use that new argument instead of an environment variable