### PR TITLE
Fix: tags being merged incorrectly when indentation isn't trivial

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -94,8 +94,8 @@ func buildMapExpression(tokens hclwrite.Tokens) string {
 	}
 
 	mapContent := string(tokens.Bytes())
-	mapContent = strings.TrimSpace(mapContent)
-	mapContent = strings.TrimSuffix(mapContent, ",") // remove any traling commas due to newline replaced
+	mapContent = strings.Replace(mapContent, " ", "", -1) // trim spaces
+	mapContent = strings.TrimSuffix(mapContent, ",")      // remove any traling commas due to newline replaced
 	return "map(" + mapContent + ")"
 }
 

--- a/test/fixture/terraform_11/aws_submodule/expected/child/child.terratag.tf
+++ b/test/fixture/terraform_11/aws_submodule/expected/child/child.terratag.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name"        , "My bucket" ,    "Environment" , "Dev"), local.terratag_added_child)}"
+  tags = "${merge( map("Name","Mybucket","Environment","Dev"), local.terratag_added_child)}"
 }
 locals {
   terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/aws_tags_block/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_block/expected/main.terratag.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name", "My bucket" ), local.terratag_added_main)}"
+  tags = "${merge( map("Name","Mybucket"), local.terratag_added_main)}"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/aws_tags_block/expected/main.tf.bak
+++ b/test/fixture/terraform_11/aws_tags_block/expected/main.tf.bak
@@ -9,6 +9,5 @@ resource "aws_s3_bucket" "b" {
 
   tags {
     Name        = "My bucket"
-    Environment = "Dev"
   }
 }

--- a/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    "${max(1, 2)}"            , "Test function" ,    "${local.localTagKey}"    , "Test expression" ,    "${local.localTagKey2}"   , "Test variable as key" ,    "Yo-${local.localTagKey}" , "Test variable inside key" ,    "Test variable as value" , "${local.localTagKey}" ,    "Test variable inside value"  , "Yo-${local.localTagKey}"), local.terratag_added_main)}"
+  tags = "${merge( map("Name","Mybucket","Unquoted1","Iwannabequoted","AnotherName","Yo","Unquoted2","Ireallywannabequoted","Unquoted3","IreallyreallywannabequotedandIgotacomma","${max(1,2)}","Testfunction","${local.localTagKey}","Testexpression","${local.localTagKey2}","Testvariableaskey","Yo-${local.localTagKey}","Testvariableinsidekey","Testvariableasvalue","${local.localTagKey}","Testvariableinsidevalue","Yo-${local.localTagKey}"), local.terratag_added_main)}"
 }
 
 resource "aws_s3_bucket" "a" {

--- a/test/fixture/terraform_11/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/azurerm_tags_map/expected/main.terratag.tf
@@ -5,7 +5,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
-  tags     = "${merge( map("oh" , "my"), local.terratag_added_main)}"
+  tags     = "${merge( map("oh","my"), local.terratag_added_main)}"
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/test/fixture/terraform_11/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/azurestack_tags_map/expected/main.terratag.tf
@@ -21,7 +21,7 @@ resource "azurestack_virtual_network" "test2" {
   address_space       = ["10.0.0.0/16"]
   location            = "${azurestack_resource_group.test.location}"
   resource_group_name = "${azurestack_resource_group.test.name}"
-  tags                = "${merge( map("yo" , "ho"), local.terratag_added_main)}"
+  tags                = "${merge( map("yo","ho"), local.terratag_added_main)}"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/google_container_cluster/expected/main.terratag.tf
@@ -26,7 +26,7 @@ resource "google_container_cluster" "existing-labels-cluster" {
   name     = "cluster2"
   location = "us-central1"
 
-  resource_labels = "${merge( map("foo" , "bar"), local.terratag_added_main)}"
+  resource_labels = "${merge( map("foo","bar"), local.terratag_added_main)}"
 
   node_config {
     machine_type = "n1-standard-1"

--- a/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "google_storage_bucket" "static-site" {
     response_header = ["*"]
     max_age_seconds = 3600
   }
-  labels = "${merge( map("foo" , "bar"), local.terratag_added_main)}"
+  labels = "${merge( map("foo","bar"), local.terratag_added_main)}"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_submodule/expected/child/child.terratag.tf
+++ b/test/fixture/terraform_12/aws_submodule/expected/child/child.terratag.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name"        , "My bucket" ,    "Environment" , "Dev"), local.terratag_added_child)
+  tags = merge( map("Name","Mybucket","Environment","Dev"), local.terratag_added_child)
 }
 locals {
   terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_tags_block/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_block/expected/main.terratag.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name", "My bucket" ), local.terratag_added_main)
+  tags = merge( map("Name","Mybucket"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    join("-", ["foo", "bar"]) , "Test function" ,    (local.localTagKey)       , "Test expression" ,    "${local.localTagKey2}"   , "Test variable as key" ,    "Yo-${local.localTagKey}" , "Test variable inside key" ,    "Test variable as value" , "${local.localTagKey}" ,    "Test variable inside value"  , "Yo-${local.localTagKey}"), local.terratag_added_main)
+  tags = merge( map("Name","Mybucket","Unquoted1","Iwannabequoted","AnotherName","Yo","Unquoted2","Ireallywannabequoted","Unquoted3","IreallyreallywannabequotedandIgotacomma",join("-",["foo","bar"]),"Testfunction",(local.localTagKey),"Testexpression","${local.localTagKey2}","Testvariableaskey","Yo-${local.localTagKey}","Testvariableinsidekey","Testvariableasvalue","${local.localTagKey}","Testvariableinsidevalue","Yo-${local.localTagKey}"), local.terratag_added_main)
 }
 
 resource "aws_s3_bucket" "a" {

--- a/test/fixture/terraform_12/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/azurerm_tags_map/expected/main.terratag.tf
@@ -5,7 +5,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
-  tags     = merge( map("oh" , "my"), local.terratag_added_main)
+  tags     = merge( map("oh","my"), local.terratag_added_main)
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/test/fixture/terraform_12/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/azurestack_tags_map/expected/main.terratag.tf
@@ -21,7 +21,7 @@ resource "azurestack_virtual_network" "test2" {
   address_space       = ["10.0.0.0/16"]
   location            = azurestack_resource_group.test.location
   resource_group_name = azurestack_resource_group.test.name
-  tags                = merge( map("yo" , "ho"), local.terratag_added_main)
+  tags                = merge( map("yo","ho"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/google_container_cluster/expected/main.terratag.tf
@@ -26,7 +26,7 @@ resource "google_container_cluster" "existing-labels-cluster" {
   name     = "cluster2"
   location = "us-central1"
 
-  resource_labels = merge( map("foo" , "bar"), local.terratag_added_main)
+  resource_labels = merge( map("foo","bar"), local.terratag_added_main)
 
   node_config {
     machine_type = "n1-standard-1"

--- a/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "google_storage_bucket" "static-site" {
     response_header = ["*"]
     max_age_seconds = 3600
   }
-  labels = merge( map("foo" , "bar"), local.terratag_added_main)
+  labels = merge( map("foo","bar"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13/aws_submodule/expected/child/child.terratag.tf
+++ b/test/fixture/terraform_13/aws_submodule/expected/child/child.terratag.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name"        , "My bucket" ,    "Environment" , "Dev"), local.terratag_added_child)
+  tags = merge( map("Name","Mybucket","Environment","Dev"), local.terratag_added_child)
 }
 locals {
   terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13/aws_tags_block/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/aws_tags_block/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name", "My bucket" ), local.terratag_added_main)
+  tags = merge( map("Name","Mybucket"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/aws_tags_map/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name"                    , "My bucket" ,    "Unquoted1"                 , "I wanna be quoted" ,    "AnotherName"             , "Yo" ,    "Unquoted2"                 , "I really wanna be quoted" ,    "Unquoted3"                 , "I really really wanna be quoted and I got a comma",    join("-", ["foo", "bar"]) , "Test function" ,    (local.localTagKey)       , "Test expression" ,    "${local.localTagKey2}"   , "Test variable as key" ,    "Yo-${local.localTagKey}" , "Test variable inside key" ,    "Test variable as value" , "${local.localTagKey}" ,    "Test variable inside value"  , "Yo-${local.localTagKey}"), local.terratag_added_main)
+  tags = merge( map("Name","Mybucket","Unquoted1","Iwannabequoted","AnotherName","Yo","Unquoted2","Ireallywannabequoted","Unquoted3","IreallyreallywannabequotedandIgotacomma",join("-",["foo","bar"]),"Testfunction",(local.localTagKey),"Testexpression","${local.localTagKey2}","Testvariableaskey","Yo-${local.localTagKey}","Testvariableinsidekey","Testvariableasvalue","${local.localTagKey}","Testvariableinsidevalue","Yo-${local.localTagKey}"), local.terratag_added_main)
 }
 
 resource "aws_s3_bucket" "a" {

--- a/test/fixture/terraform_13/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/azurerm_tags_map/expected/main.terratag.tf
@@ -13,7 +13,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
-  tags     = merge( map("oh" , "my"), local.terratag_added_main)
+  tags     = merge( map("oh","my"), local.terratag_added_main)
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/test/fixture/terraform_13/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/azurestack_tags_map/expected/main.terratag.tf
@@ -26,7 +26,7 @@ resource "azurestack_virtual_network" "test2" {
   address_space       = ["10.0.0.0/16"]
   location            = azurestack_resource_group.test.location
   resource_group_name = azurestack_resource_group.test.name
-  tags                = merge( map("yo" , "ho"), local.terratag_added_main)
+  tags                = merge( map("yo","ho"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/google_container_cluster/expected/main.terratag.tf
@@ -34,7 +34,7 @@ resource "google_container_cluster" "existing-labels-cluster" {
   name     = "cluster2"
   location = "us-central1"
 
-  resource_labels = merge( map("foo" , "bar"), local.terratag_added_main)
+  resource_labels = merge( map("foo","bar"), local.terratag_added_main)
 
   node_config {
     machine_type = "n1-standard-1"

--- a/test/fixture/terraform_13/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/google_labels_map/expected/main.terratag.tf
@@ -23,7 +23,7 @@ resource "google_storage_bucket" "static-site" {
     response_header = ["*"]
     max_age_seconds = 3600
   }
-  labels = merge( map("foo" , "bar"), local.terratag_added_main)
+  labels = merge( map("foo","bar"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}


### PR DESCRIPTION
Fixes #33 

### Issue
We currently remove the last 2 characters of an HCL attribute before we parse it, with the assumption that these 2 characters are of types `hclsyntax.TokenNewline` (`\n`) and `hclsyntax.TokenCBrace` (`}`). When an HCL attribute map doesn't use a trivial indented syntax, this fails because there is no new line.

### Solution
Remove leading/trailing relevant characters based on their type, and not their order. 
Also, since all test files were about to change due to removal of some unnecessary spaces, I've trimmed all spaces of output map content so it'd look cleaner 😇 