### PR TITLE
Create different binary release artifacts and homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,71 +1,27 @@
+name: release
+
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-
-name: Upload Release Asset
+    - "v[0-9]+.*"
 
 jobs:
-  build:
-    name: Upload Release Asset
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
-      
-      - name: Build project
-        run: |
-          mkdir out
-          CGO_ENABLED=0 go build -a -installsuffix cgo -o ./out/terratag/terratag
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Terratag ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      # Setup .npmrc file to publish to GitHub Packages
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@env0'
-
-      - run: |
-          npm init --yes --scope @env0
-          ref=${{ github.ref }}
-          tag=\"${ref#"refs/tags/v"}\"
-          echo "`jq .version="${tag}" package.json`" > package.json
-        working-directory: ./out/terratag
-
-      # Need to get version from release
-      - run: npm publish ./out/terratag
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./out/terratag/terratag
-          asset_name: terratag-linux
-          asset_content_type: application/zip
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
Use [goreleaser-action](https://github.com/marketplace/actions/goreleaser-action) to release to multiple platforms and update the [homebrew tap](https://github.com/env0/terratag-homebrew)