### PR TITLE
Fix: tag azurerm_kubernetes_cluster resource default node pool

### DIFF
--- a/tagging/azure.go
+++ b/tagging/azure.go
@@ -1,0 +1,17 @@
+package tagging
+
+func tagAksK8sCluster(args TagBlockArgs) Result {
+	var swappedTagsStrings []string
+
+	// handle root block tags attribute
+	swappedTagsStrings = append(swappedTagsStrings, TagBlock(args))
+
+	// handle default_node_pool tags attribute
+	nodePool := args.Block.Body().FirstMatchingBlock("default_node_pool", nil)
+	if nodePool != nil {
+		args.Block = nodePool
+		swappedTagsStrings = append(swappedTagsStrings, TagBlock(args))
+	}
+
+	return Result{SwappedTagsStrings: swappedTagsStrings}
+}

--- a/tagging/tagging.go
+++ b/tagging/tagging.go
@@ -53,8 +53,9 @@ func TagResource(args TagBlockArgs) Result {
 }
 
 var resourceTypeToFnMap = map[string]TagResourceFn{
-	"aws_autoscaling_group":    tagAutoscalingGroup,
-	"google_container_cluster": tagContainerCluster,
+	"aws_autoscaling_group":      tagAutoscalingGroup,
+	"google_container_cluster":   tagContainerCluster,
+	"azurerm_kubernetes_cluster": tagAksK8sCluster,
 }
 
 type TagBlockArgs struct {

--- a/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -1,0 +1,76 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+  tags     = "${local.terratag_added_main}"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = "${azurerm_resource_group.non_existing_tags_rg.location}"
+  resource_group_name = "${azurerm_resource_group.non_existing_tags_rg.name}"
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = "${local.terratag_added_main}"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = "${local.terratag_added_main}"
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+  tags     = "${local.terratag_added_main}"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = "${azurerm_resource_group.existing_tags_rg.location}"
+  resource_group_name = "${azurerm_resource_group.existing_tags_rg.name}"
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = "${merge( map("existing","tag"), local.terratag_added_main)}"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = "${merge( map("existing","tag"), local.terratag_added_main)}"
+}
+
+
+
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -67,9 +67,6 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
   tags = "${merge( map("existing","tag"), local.terratag_added_main)}"
 }
 
-
-
-
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.tf.bak
@@ -1,0 +1,71 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = "${azurerm_resource_group.non_existing_tags_rg.location}"
+  resource_group_name = "${azurerm_resource_group.non_existing_tags_rg.name}"
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = "${azurerm_resource_group.existing_tags_rg.location}"
+  resource_group_name = "${azurerm_resource_group.existing_tags_rg.name}"
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}
+
+
+

--- a/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.tf.bak
@@ -66,6 +66,3 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     existing = "tag"
   }
 }
-
-
-

--- a/test/fixture/terraform_11/azurerm_kubernetes_cluster/input/main.tf
+++ b/test/fixture/terraform_11/azurerm_kubernetes_cluster/input/main.tf
@@ -1,0 +1,71 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = "${azurerm_resource_group.non_existing_tags_rg.location}"
+  resource_group_name = "${azurerm_resource_group.non_existing_tags_rg.name}"
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = "${azurerm_resource_group.existing_tags_rg.location}"
+  resource_group_name = "${azurerm_resource_group.existing_tags_rg.name}"
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}
+
+
+

--- a/test/fixture/terraform_11/azurerm_kubernetes_cluster/input/main.tf
+++ b/test/fixture/terraform_11/azurerm_kubernetes_cluster/input/main.tf
@@ -66,6 +66,3 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     existing = "tag"
   }
 }
-
-
-

--- a/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -67,9 +67,6 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
   tags = merge( map("existing","tag"), local.terratag_added_main)
 }
 
-
-
-
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -1,0 +1,76 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = local.terratag_added_main
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = local.terratag_added_main
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = merge( map("existing","tag"), local.terratag_added_main)
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = merge( map("existing","tag"), local.terratag_added_main)
+}
+
+
+
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.tf.bak
@@ -1,0 +1,71 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}
+
+
+

--- a/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.tf.bak
@@ -66,6 +66,3 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     existing = "tag"
   }
 }
-
-
-

--- a/test/fixture/terraform_12/azurerm_kubernetes_cluster/input/main.tf
+++ b/test/fixture/terraform_12/azurerm_kubernetes_cluster/input/main.tf
@@ -1,0 +1,71 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}
+
+
+

--- a/test/fixture/terraform_12/azurerm_kubernetes_cluster/input/main.tf
+++ b/test/fixture/terraform_12/azurerm_kubernetes_cluster/input/main.tf
@@ -66,6 +66,3 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     existing = "tag"
   }
 }
-
-
-

--- a/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -67,9 +67,6 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
   tags = merge( map("existing","tag"), local.terratag_added_main)
 }
 
-
-
-
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -1,0 +1,76 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = local.terratag_added_main
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = local.terratag_added_main
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = merge( map("existing","tag"), local.terratag_added_main)
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = merge( map("existing","tag"), local.terratag_added_main)
+}
+
+
+
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.tf.bak
@@ -1,0 +1,71 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}
+
+
+

--- a/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_13/azurerm_kubernetes_cluster/expected/main.tf.bak
@@ -66,6 +66,3 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     existing = "tag"
   }
 }
-
-
-

--- a/test/fixture/terraform_13/azurerm_kubernetes_cluster/input/main.tf
+++ b/test/fixture/terraform_13/azurerm_kubernetes_cluster/input/main.tf
@@ -1,0 +1,71 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}
+
+
+

--- a/test/fixture/terraform_13/azurerm_kubernetes_cluster/input/main.tf
+++ b/test/fixture/terraform_13/azurerm_kubernetes_cluster/input/main.tf
@@ -66,6 +66,3 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     existing = "tag"
   }
 }
-
-
-


### PR DESCRIPTION
### Issue
Tagging an AKS k8s cluster is done without modifying the `default_node_pool` attribute which is in charge of the VMSS tags.

### Solution
Add a custom function to handle `azurerm_kubernetes_cluster` resource types that modifies the `tags` attribute of the `default_node_pool` nested block.