### PR TITLE
Fix: support aliased provider names

### DIFF
--- a/test/fixture/terraform_13/git_issue_66_aws_aliased_provider/expected/main.terratag.tf
+++ b/test/fixture/terraform_13/git_issue_66_aws_aliased_provider/expected/main.terratag.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "custom"
+  version = "~> 3.0"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  provider = aws.custom
+
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+  tags   = local.terratag_added_main
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13/git_issue_66_aws_aliased_provider/expected/main.tf.bak
+++ b/test/fixture/terraform_13/git_issue_66_aws_aliased_provider/expected/main.tf.bak
@@ -1,0 +1,12 @@
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "custom"
+  version = "~> 3.0"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  provider = aws.custom
+
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+}

--- a/test/fixture/terraform_13/git_issue_66_aws_aliased_provider/input/main.tf
+++ b/test/fixture/terraform_13/git_issue_66_aws_aliased_provider/input/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "custom"
+  version = "~> 3.0"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  provider = aws.custom
+
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+}


### PR DESCRIPTION
fixes #66 

### Solution
Instead of having a generic solution that captures every custom provider name specified, we'll support a pre-defined set of providers, currently containing only `google-beta`.