### PR TITLE
Dockerfile for github action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+attic
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang AS build
+
+WORKDIR /usr/src
+COPY . .
+RUN rm -f terratag && go build -ldflags "-linkmode external -extldflags -static"
+
+FROM hashicorp/terraform:light
+COPY --from=build /usr/src/terratag /bin/terratag
+ENTRYPOINT ["/bin/terratag"]


### PR DESCRIPTION
1. build docker:
`docker build . -t terratag`

2. upload docker (make sure to enable github container registry https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images)
`docker tag terratag ghcr.io/env0/terratag`
`docker push ghcr.io/env0/terratag`
also, make sure the terratag package is public (under organization packages)

3. to use as a github action, add a step:
```
  - name: run terratag
    uses: docker://ghcr.io/env0/terratag
    with:
        args: -tags=<tags json> -dir=/github/workspace/<path inside project>
```
this is not tested, as env0 needs to build and publish this container. this is what i actually tested:
```
name: test terratag action

on: push

jobs:

  test:
    name: test
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: alpine
        uses: docker://alpine
        with:
            entrypoint: /bin/ls
            args: /github/workspace
      - name: run terraform init
        uses: docker://ghcr.io/shlomimatichin/terratag
        with:
            entrypoint: /bin/sh
            args: -c "cd /github/workspace/test/fixture/terraform_13/aws_autoscaling_group/input && terraform init"
      - name: run terratag
        uses: docker://ghcr.io/shlomimatichin/terratag
        with:
            args: -tags={\"env0_environment_id\":\"40907eff-cf7c-419a-8694-e1c6bf1d1168\",\"env0_project_id\":\"43fd4ff1-8d37-4d9d-ac97-295bd850bf94\"} -dir=/github/workspace/test/fixture/terraform_13/aws_autoscaling_group/input
```