### PR TITLE
GitHub Action - Do not use deprecated add-path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
           wget https://github.com/minamijoyo/tfschema/releases/download/v0.3.0/tfschema_0.3.0_linux_amd64.tar.gz
           mkdir $GITHUB_WORKSPACE/.tfschema
           tar -xvf tfschema_0.3.0_linux_amd64.tar.gz -C $GITHUB_WORKSPACE/.tfschema
-          echo "::add-path::$GITHUB_WORKSPACE/.tfschema"
+          echo "$GITHUB_WORKSPACE/.tfschema" >> $GITHUB_PATH
 
       - name: Install tfenv
         run: |
           git clone https://github.com/tfutils/tfenv.git $GITHUB_WORKSPACE/.tfenv
-          echo "::add-path::$GITHUB_WORKSPACE/.tfenv/bin"
+          echo "$GITHUB_WORKSPACE/.tfenv/bin" >> $GITHUB_PATH
 
       - name: Install terraform
         working-directory: test/fixture/terraform_${{ matrix.terraform_version }}


### PR DESCRIPTION
CI fails as GitHub deprecated `add-path` in favor of [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)