### PR TITLE
Fix: New lines in modified attributes 

### DIFF
--- a/tagging/tagging.go
+++ b/tagging/tagging.go
@@ -38,7 +38,7 @@ func TagBlock(args TagBlockArgs) string {
 	}
 
 	if args.TfVersion == 11 {
-		newTagsValue = "${" + newTagsValue + "}"
+		newTagsValue = "\"${" + newTagsValue + "}\""
 	}
 
 	newTagsValueTokens := ParseHclValueStringToTokens(newTagsValue)

--- a/tagging/tagging.go
+++ b/tagging/tagging.go
@@ -6,7 +6,6 @@ import (
 	"github.com/env0/terratag/terraform"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"log"
 )
 
@@ -42,69 +41,8 @@ func TagBlock(args TagBlockArgs) string {
 		newTagsValue = "${" + newTagsValue + "}"
 	}
 
-	mergeCommand := &hclwrite.Token{
-		Type:         hclsyntax.TokenIdent,
-		Bytes:        []byte("merge"),
-		SpacesBefore: 0,
-	}
-
-	localPrefix := &hclwrite.Token{
-		Type:         hclsyntax.TokenIdent,
-		Bytes:        []byte("local"),
-		SpacesBefore: 0,
-	}
-
-	dotToken := &hclwrite.Token{
-		Type:         hclsyntax.TokenDot,
-		Bytes:        []byte("."),
-		SpacesBefore: 0,
-	}
-
-	terraTagLocal := &hclwrite.Token{
-		Type:         hclsyntax.TokenIdent,
-		Bytes:        []byte(tag_keys.GetTerratagAddedKey(args.Filename)),
-		SpacesBefore: 0,
-	}
-
-	comma := &hclwrite.Token{
-		Type:         hclsyntax.TokenComma,
-		Bytes:        []byte(","),
-		SpacesBefore: 0,
-	}
-
-	openParen := &hclwrite.Token{
-		Type:         hclsyntax.TokenOParen,
-		Bytes:        []byte("("),
-		SpacesBefore: 0,
-	} 
-
-	newLine := &hclwrite.Token{
-		Type:         hclsyntax.TokenNewline,
-		Bytes:        []byte(""),
-		SpacesBefore: 0,
-	} 
-	
-	closeParen := &hclwrite.Token{
-		Type:         hclsyntax.TokenCParen,
-		Bytes:        []byte(")"),
-		SpacesBefore: 0,
-	} 
-
-	existingTags := args.Block.Body().GetAttribute(args.TagId)
-	existingTagsTokens := existingTags.Expr().BuildTokens(hclwrite.Tokens{})
-
-	var newTokens hclwrite.Tokens
-	newTokens = append(newTokens, mergeCommand, openParen, newLine)
-	newTokens = append(newTokens, existingTagsTokens...)
-	newTokens = append(newTokens, newLine, comma, localPrefix, dotToken, terraTagLocal, closeParen)
-
-	for _, token := range existingTagsTokens {
-		log.Print(token.Type)
-		log.Print(string(token.Bytes))
-	}
-
-	// newTagsValueTokens := ParseHclValueStringToTokens(newTagsValue)
-	args.Block.Body().SetAttributeRaw(args.TagId, newTokens)
+	newTagsValueTokens := ParseHclValueStringToTokens(newTagsValue)
+	args.Block.Body().SetAttributeRaw(args.TagId, newTagsValueTokens)
 
 	return newTagsValue
 }

--- a/tagging/tagging.go
+++ b/tagging/tagging.go
@@ -5,7 +5,8 @@ import (
 	"github.com/env0/terratag/tag_keys"
 	"github.com/env0/terratag/terraform"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/zclconf/go-cty/cty"
+	"github.com/hashicorp/hcl/v2"
+	"log"
 )
 
 func defaultTaggingFn(args TagBlockArgs) Result {
@@ -14,23 +15,36 @@ func defaultTaggingFn(args TagBlockArgs) Result {
 	}
 }
 
+func ParseHclValueStringToTokens(hclValueString string) hclwrite.Tokens {
+	file, diags := hclwrite.ParseConfig([]byte("tempKey = " + hclValueString), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		log.Print("error parsing hcl value string " + hclValueString)
+		panic(diags.Errs()[0])
+	}
+	tempAttribute := file.Body().GetAttribute("tempKey")
+	return tempAttribute.Expr().BuildTokens(hclwrite.Tokens{})
+}
+
 func TagBlock(args TagBlockArgs) string {
 	hasExistingTags := convert.MoveExistingTags(args.Filename, args.Terratag, args.Block, args.TagId)
+	
+	terratagAddedKey := "local." + tag_keys.GetTerratagAddedKey(args.Filename)
+	newTagsValue := terratagAddedKey
 
-	tagsValue := ""
 	if hasExistingTags {
-		tagsValue = "merge( " + convert.GetExistingTagsExpression(args.Terratag.Found[tag_keys.GetResourceExistingTagsKey(args.Filename, args.Block)]) + ", local." + tag_keys.GetTerratagAddedKey(args.Filename) + ")"
-	} else {
-		tagsValue = "local." + tag_keys.GetTerratagAddedKey(args.Filename)
+		existingTagsKey := tag_keys.GetResourceExistingTagsKey(args.Filename, args.Block)
+		existingTagsExpression := convert.GetExistingTagsExpression(args.Terratag.Found[existingTagsKey])
+		newTagsValue = "merge( " + existingTagsExpression + ", " + terratagAddedKey + ")"
 	}
 
 	if args.TfVersion == 11 {
-		tagsValue = "${" + tagsValue + "}"
+		newTagsValue = "${" + newTagsValue + "}"
 	}
 
-	args.Block.Body().SetAttributeValue(args.TagId, cty.StringVal(tagsValue))
+	newTagsValueTokens := ParseHclValueStringToTokens(newTagsValue)
+	args.Block.Body().SetAttributeRaw(args.TagId, newTagsValueTokens)
 
-	return tagsValue
+	return newTagsValue
 }
 
 func HasResourceTagFn(resourceType string) bool {

--- a/tagging/tagging.go
+++ b/tagging/tagging.go
@@ -6,6 +6,7 @@ import (
 	"github.com/env0/terratag/terraform"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"log"
 )
 
@@ -41,8 +42,69 @@ func TagBlock(args TagBlockArgs) string {
 		newTagsValue = "${" + newTagsValue + "}"
 	}
 
-	newTagsValueTokens := ParseHclValueStringToTokens(newTagsValue)
-	args.Block.Body().SetAttributeRaw(args.TagId, newTagsValueTokens)
+	mergeCommand := &hclwrite.Token{
+		Type:         hclsyntax.TokenIdent,
+		Bytes:        []byte("merge"),
+		SpacesBefore: 0,
+	}
+
+	localPrefix := &hclwrite.Token{
+		Type:         hclsyntax.TokenIdent,
+		Bytes:        []byte("local"),
+		SpacesBefore: 0,
+	}
+
+	dotToken := &hclwrite.Token{
+		Type:         hclsyntax.TokenDot,
+		Bytes:        []byte("."),
+		SpacesBefore: 0,
+	}
+
+	terraTagLocal := &hclwrite.Token{
+		Type:         hclsyntax.TokenIdent,
+		Bytes:        []byte(tag_keys.GetTerratagAddedKey(args.Filename)),
+		SpacesBefore: 0,
+	}
+
+	comma := &hclwrite.Token{
+		Type:         hclsyntax.TokenComma,
+		Bytes:        []byte(","),
+		SpacesBefore: 0,
+	}
+
+	openParen := &hclwrite.Token{
+		Type:         hclsyntax.TokenOParen,
+		Bytes:        []byte("("),
+		SpacesBefore: 0,
+	} 
+
+	newLine := &hclwrite.Token{
+		Type:         hclsyntax.TokenNewline,
+		Bytes:        []byte(""),
+		SpacesBefore: 0,
+	} 
+	
+	closeParen := &hclwrite.Token{
+		Type:         hclsyntax.TokenCParen,
+		Bytes:        []byte(")"),
+		SpacesBefore: 0,
+	} 
+
+	existingTags := args.Block.Body().GetAttribute(args.TagId)
+	existingTagsTokens := existingTags.Expr().BuildTokens(hclwrite.Tokens{})
+
+	var newTokens hclwrite.Tokens
+	newTokens = append(newTokens, mergeCommand, openParen, newLine)
+	newTokens = append(newTokens, existingTagsTokens...)
+	newTokens = append(newTokens, newLine, comma, localPrefix, dotToken, terraTagLocal, closeParen)
+
+	for _, token := range existingTagsTokens {
+		log.Print(token.Type)
+		log.Print(string(token.Bytes))
+	}
+
+	// newTagsValueTokens := ParseHclValueStringToTokens(newTagsValue)
+	args.Block.Body().SetAttributeRaw(args.TagId, newTokens)
 
 	return newTagsValue
 }

--- a/test/fixture/terraform_11/aws_submodule/expected/child/child.terratag.tf
+++ b/test/fixture/terraform_11/aws_submodule/expected/child/child.terratag.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name","Mybucket","Environment","Dev"), local.terratag_added_child)}"
+  tags = "${merge(map("Name", "Mybucket", "Environment", "Dev"), local.terratag_added_child)}"
 }
 locals {
   terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/aws_tags_block/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_block/expected/main.terratag.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name","Mybucket"), local.terratag_added_main)}"
+  tags = "${merge(map("Name", "Mybucket"), local.terratag_added_main)}"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_map/expected/main.terratag.tf
@@ -7,14 +7,14 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( map("Name","Mybucket","Unquoted1","Iwannabequoted","AnotherName","Yo","Unquoted2","Ireallywannabequoted","Unquoted3","IreallyreallywannabequotedandIgotacomma","${max(1,2)}","Testfunction","${local.localTagKey}","Testexpression","${local.localTagKey2}","Testvariableaskey","Yo-${local.localTagKey}","Testvariableinsidekey","Testvariableasvalue","${local.localTagKey}","Testvariableinsidevalue","Yo-${local.localTagKey}"), local.terratag_added_main)}"
+  tags = "${merge(map("Name", "Mybucket", "Unquoted1", "Iwannabequoted", "AnotherName", "Yo", "Unquoted2", "Ireallywannabequoted", "Unquoted3", "IreallyreallywannabequotedandIgotacomma", "${max(1, 2)}", "Testfunction", "${local.localTagKey}", "Testexpression", "${local.localTagKey2}", "Testvariableaskey", "Yo-${local.localTagKey}", "Testvariableinsidekey", "Testvariableasvalue", "${local.localTagKey}", "Testvariableinsidevalue", "Yo-${local.localTagKey}"), local.terratag_added_main)}"
 }
 
 resource "aws_s3_bucket" "a" {
   bucket = "my-another-tf-test-bucket"
   acl    = "private"
 
-  tags = "${merge( "${local.localMap}", local.terratag_added_main)}"
+  tags = "${merge("${local.localMap}", local.terratag_added_main)}"
 }
 
 

--- a/test/fixture/terraform_11/aws_tags_merge/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_merge/expected/main.terratag.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+
+  tags = "${merge( "${merge(map("a", "b"), map("c", "d"))}", local.terratag_added_main)}"
+}
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_11/aws_tags_merge/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/aws_tags_merge/expected/main.terratag.tf
@@ -6,7 +6,10 @@ provider "aws" {
 resource "aws_s3_bucket" "a" {
   bucket = "my-another-tf-test-bucket"
 
-  tags = "${merge( "${merge(map("a", "b"), map("c", "d"))}", local.terratag_added_main)}"
+  tags = "${merge("${merge(
+    map("a", "b"),
+    map("c", "d")
+  )}", local.terratag_added_main)}"
 }
 
 locals {

--- a/test/fixture/terraform_11/aws_tags_merge/expected/main.tf.bak
+++ b/test/fixture/terraform_11/aws_tags_merge/expected/main.tf.bak
@@ -6,5 +6,8 @@ provider "aws" {
 resource "aws_s3_bucket" "a" {
   bucket = "my-another-tf-test-bucket"
 
-  tags = "${merge(map("a", "b"), map("c", "d"))}"
+  tags = "${merge(
+    map("a", "b"), 
+    map("c", "d")
+  )}"
 }

--- a/test/fixture/terraform_11/aws_tags_merge/expected/main.tf.bak
+++ b/test/fixture/terraform_11/aws_tags_merge/expected/main.tf.bak
@@ -1,0 +1,10 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+
+  tags = "${merge(map("a", "b"), map("c", "d"))}"
+}

--- a/test/fixture/terraform_11/aws_tags_merge/input/main.tf
+++ b/test/fixture/terraform_11/aws_tags_merge/input/main.tf
@@ -6,5 +6,8 @@ provider "aws" {
 resource "aws_s3_bucket" "a" {
   bucket = "my-another-tf-test-bucket"
 
-  tags = "${merge(map("a", "b"), map("c", "d"))}"
+  tags = "${merge(
+    map("a", "b"), 
+    map("c", "d")
+  )}"
 }

--- a/test/fixture/terraform_11/aws_tags_merge/input/main.tf
+++ b/test/fixture/terraform_11/aws_tags_merge/input/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+
+  tags = "${merge(map("a", "b"), map("c", "d"))}"
+}

--- a/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -56,7 +56,7 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     name       = "pool"
     node_count = 2
     vm_size    = "Standard_D2_v2"
-    tags       = "${merge( map("existing","tag"), local.terratag_added_main)}"
+    tags       = "${merge(map("existing", "tag"), local.terratag_added_main)}"
   }
 
   network_profile {
@@ -64,7 +64,7 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     network_plugin    = "kubenet"
   }
 
-  tags = "${merge( map("existing","tag"), local.terratag_added_main)}"
+  tags = "${merge(map("existing", "tag"), local.terratag_added_main)}"
 }
 
 locals {

--- a/test/fixture/terraform_11/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/azurerm_tags_map/expected/main.terratag.tf
@@ -5,7 +5,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
-  tags     = "${merge( map("oh","my"), local.terratag_added_main)}"
+  tags     = "${merge(map("oh", "my"), local.terratag_added_main)}"
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/test/fixture/terraform_11/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/azurestack_tags_map/expected/main.terratag.tf
@@ -21,7 +21,7 @@ resource "azurestack_virtual_network" "test2" {
   address_space       = ["10.0.0.0/16"]
   location            = "${azurestack_resource_group.test.location}"
   resource_group_name = "${azurestack_resource_group.test.name}"
-  tags                = "${merge( map("yo","ho"), local.terratag_added_main)}"
+  tags                = "${merge(map("yo", "ho"), local.terratag_added_main)}"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_11/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/google_container_cluster/expected/main.terratag.tf
@@ -26,7 +26,7 @@ resource "google_container_cluster" "existing-labels-cluster" {
   name     = "cluster2"
   location = "us-central1"
 
-  resource_labels = "${merge( map("foo","bar"), local.terratag_added_main)}"
+  resource_labels = "${merge(map("foo", "bar"), local.terratag_added_main)}"
 
   node_config {
     machine_type = "n1-standard-1"

--- a/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "google_storage_bucket" "static-site" {
     response_header = ["*"]
     max_age_seconds = 3600
   }
-  labels = "${merge( map("foo","bar"), local.terratag_added_main)}"
+  labels = "${merge(map("foo", "bar"), local.terratag_added_main)}"
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_submodule/expected/child/child.terratag.tf
+++ b/test/fixture/terraform_12/aws_submodule/expected/child/child.terratag.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name","Mybucket","Environment","Dev"), local.terratag_added_child)
+  tags = merge(map("Name", "Mybucket", "Environment", "Dev"), local.terratag_added_child)
 }
 locals {
   terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_tags_block/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_block/expected/main.terratag.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name","Mybucket"), local.terratag_added_main)
+  tags = merge(map("Name", "Mybucket"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_map/expected/main.terratag.tf
@@ -7,14 +7,14 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name","Mybucket","Unquoted1","Iwannabequoted","AnotherName","Yo","Unquoted2","Ireallywannabequoted","Unquoted3","IreallyreallywannabequotedandIgotacomma",join("-",["foo","bar"]),"Testfunction",(local.localTagKey),"Testexpression","${local.localTagKey2}","Testvariableaskey","Yo-${local.localTagKey}","Testvariableinsidekey","Testvariableasvalue","${local.localTagKey}","Testvariableinsidevalue","Yo-${local.localTagKey}"), local.terratag_added_main)
+  tags = merge(map("Name", "Mybucket", "Unquoted1", "Iwannabequoted", "AnotherName", "Yo", "Unquoted2", "Ireallywannabequoted", "Unquoted3", "IreallyreallywannabequotedandIgotacomma", join("-", ["foo", "bar"]), "Testfunction", (local.localTagKey), "Testexpression", "${local.localTagKey2}", "Testvariableaskey", "Yo-${local.localTagKey}", "Testvariableinsidekey", "Testvariableasvalue", "${local.localTagKey}", "Testvariableinsidevalue", "Yo-${local.localTagKey}"), local.terratag_added_main)
 }
 
 resource "aws_s3_bucket" "a" {
   bucket = "my-another-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( local.localMap, local.terratag_added_main)
+  tags = merge(local.localMap, local.terratag_added_main)
 }
 
 locals {

--- a/test/fixture/terraform_12/aws_tags_merge/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/aws_tags_merge/expected/main.terratag.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+variable "name" {
+  type    = string
+  default = ""
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket        = "example"
+  acl           = "public-read"
+  force_destroy = true
+
+  tags = merge(merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags
+  ), local.terratag_added_main)
+}
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_12/aws_tags_merge/expected/main.tf.bak
+++ b/test/fixture/terraform_12/aws_tags_merge/expected/main.tf.bak
@@ -1,0 +1,27 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+variable "name" {
+  type    = string
+  default = ""
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket        = "example"
+  acl           = "public-read"
+  force_destroy = true
+
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags
+  )
+}

--- a/test/fixture/terraform_12/aws_tags_merge/input/main.tf
+++ b/test/fixture/terraform_12/aws_tags_merge/input/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+variable "name" {
+  type    = string
+  default = ""
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket        = "example"
+  acl           = "public-read"
+  force_destroy = true
+
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags
+  )
+}

--- a/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -56,7 +56,7 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     name       = "pool"
     node_count = 2
     vm_size    = "Standard_D2_v2"
-    tags       = merge( map("existing","tag"), local.terratag_added_main)
+    tags       = merge(map("existing", "tag"), local.terratag_added_main)
   }
 
   network_profile {
@@ -64,7 +64,7 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     network_plugin    = "kubenet"
   }
 
-  tags = merge( map("existing","tag"), local.terratag_added_main)
+  tags = merge(map("existing", "tag"), local.terratag_added_main)
 }
 
 locals {

--- a/test/fixture/terraform_12/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/azurerm_tags_map/expected/main.terratag.tf
@@ -5,7 +5,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
-  tags     = merge( map("oh","my"), local.terratag_added_main)
+  tags     = merge(map("oh", "my"), local.terratag_added_main)
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/test/fixture/terraform_12/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/azurestack_tags_map/expected/main.terratag.tf
@@ -21,7 +21,7 @@ resource "azurestack_virtual_network" "test2" {
   address_space       = ["10.0.0.0/16"]
   location            = azurestack_resource_group.test.location
   resource_group_name = azurestack_resource_group.test.name
-  tags                = merge( map("yo","ho"), local.terratag_added_main)
+  tags                = merge(map("yo", "ho"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_12/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/google_container_cluster/expected/main.terratag.tf
@@ -26,7 +26,7 @@ resource "google_container_cluster" "existing-labels-cluster" {
   name     = "cluster2"
   location = "us-central1"
 
-  resource_labels = merge( map("foo","bar"), local.terratag_added_main)
+  resource_labels = merge(map("foo", "bar"), local.terratag_added_main)
 
   node_config {
     machine_type = "n1-standard-1"

--- a/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "google_storage_bucket" "static-site" {
     response_header = ["*"]
     max_age_seconds = 3600
   }
-  labels = merge( map("foo","bar"), local.terratag_added_main)
+  labels = merge(map("foo", "bar"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13_14/aws_submodule/expected/child/child.terratag.tf
+++ b/test/fixture/terraform_13_14/aws_submodule/expected/child/child.terratag.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name","Mybucket","Environment","Dev"), local.terratag_added_child)
+  tags = merge(map("Name", "Mybucket", "Environment", "Dev"), local.terratag_added_child)
 }
 locals {
   terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13_14/aws_tags_block/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/aws_tags_block/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name","Mybucket"), local.terratag_added_main)
+  tags = merge(map("Name", "Mybucket"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13_14/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/aws_tags_map/expected/main.terratag.tf
@@ -15,14 +15,14 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name","Mybucket","Unquoted1","Iwannabequoted","AnotherName","Yo","Unquoted2","Ireallywannabequoted","Unquoted3","IreallyreallywannabequotedandIgotacomma",join("-",["foo","bar"]),"Testfunction",(local.localTagKey),"Testexpression","${local.localTagKey2}","Testvariableaskey","Yo-${local.localTagKey}","Testvariableinsidekey","Testvariableasvalue","${local.localTagKey}","Testvariableinsidevalue","Yo-${local.localTagKey}"), local.terratag_added_main)
+  tags = merge(map("Name", "Mybucket", "Unquoted1", "Iwannabequoted", "AnotherName", "Yo", "Unquoted2", "Ireallywannabequoted", "Unquoted3", "IreallyreallywannabequotedandIgotacomma", join("-", ["foo", "bar"]), "Testfunction", (local.localTagKey), "Testexpression", "${local.localTagKey2}", "Testvariableaskey", "Yo-${local.localTagKey}", "Testvariableinsidekey", "Testvariableasvalue", "${local.localTagKey}", "Testvariableinsidevalue", "Yo-${local.localTagKey}"), local.terratag_added_main)
 }
 
 resource "aws_s3_bucket" "a" {
   bucket = "my-another-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( local.localMap, local.terratag_added_main)
+  tags = merge(local.localMap, local.terratag_added_main)
 }
 
 locals {

--- a/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -56,7 +56,7 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     name       = "pool"
     node_count = 2
     vm_size    = "Standard_D2_v2"
-    tags       = merge( map("existing","tag"), local.terratag_added_main)
+    tags       = merge(map("existing", "tag"), local.terratag_added_main)
   }
 
   network_profile {
@@ -64,7 +64,7 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     network_plugin    = "kubenet"
   }
 
-  tags = merge( map("existing","tag"), local.terratag_added_main)
+  tags = merge(map("existing", "tag"), local.terratag_added_main)
 }
 
 locals {

--- a/test/fixture/terraform_13_14/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/azurerm_tags_map/expected/main.terratag.tf
@@ -13,7 +13,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
-  tags     = merge( map("oh","my"), local.terratag_added_main)
+  tags     = merge(map("oh", "my"), local.terratag_added_main)
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/test/fixture/terraform_13_14/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/azurestack_tags_map/expected/main.terratag.tf
@@ -26,7 +26,7 @@ resource "azurestack_virtual_network" "test2" {
   address_space       = ["10.0.0.0/16"]
   location            = azurestack_resource_group.test.location
   resource_group_name = azurestack_resource_group.test.name
-  tags                = merge( map("yo","ho"), local.terratag_added_main)
+  tags                = merge(map("yo", "ho"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge( map("Name","Mybucket"), local.terratag_added_main)
+  tags = merge(map("Name", "Mybucket"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/expected/main.terratag.tf
@@ -25,7 +25,7 @@ resource "kubernetes_deployment" "audit_server" {
 
 resource "google_pubsub_topic" "audit_topic" {
   name   = "yuvu"
-  labels = merge( local.terratag_added_main, local.terratag_added_main)
+  labels = merge(local.terratag_added_main, local.terratag_added_main)
 }
 
 locals {

--- a/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
@@ -34,7 +34,7 @@ resource "google_container_cluster" "existing-labels-cluster" {
   name     = "cluster2"
   location = "us-central1"
 
-  resource_labels = merge( map("foo","bar"), local.terratag_added_main)
+  resource_labels = merge(map("foo", "bar"), local.terratag_added_main)
 
   node_config {
     machine_type = "n1-standard-1"

--- a/test/fixture/terraform_13_14/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/google_labels_map/expected/main.terratag.tf
@@ -23,7 +23,7 @@ resource "google_storage_bucket" "static-site" {
     response_header = ["*"]
     max_age_seconds = 3600
   }
-  labels = merge( map("foo","bar"), local.terratag_added_main)
+  labels = merge(map("foo", "bar"), local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}


### PR DESCRIPTION
Fixes #71 

Instead of inserting our modified tags as a string, 
We will pass them through HCL Parse and insert them as raw tokens.

That way newlines are inserted correctly instead of as `\n`

- A lot of test files were changed here because the output is slightly different - it's just whitespace changes - so reviewing with whitespaces off is recommended 