### PR TITLE
Re-add tf 13 and 14 tests that were removed

### DIFF
--- a/test/fixture/terraform_13_14/aws_autoscaling_group/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/aws_autoscaling_group/expected/main.terratag.tf
@@ -1,0 +1,76 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_placement_group" "test" {
+  name     = "test"
+  strategy = "cluster"
+  tags     = local.terratag_added_main
+}
+
+resource "aws_autoscaling_group" "bar" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  initial_lifecycle_hook {
+    name                 = "foobar"
+    default_result       = "CONTINUE"
+    heartbeat_timeout    = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+
+    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
+    role_arn                = "arn:aws:iam::123456789012:role/S3Access"
+  }
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+
+  timeouts {
+    delete = "15m"
+  }
+
+  tag {
+    key                 = "lorem"
+    value               = "ipsum"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "env0_environment_id"
+    value               = "40907eff-cf7c-419a-8694-e1c6bf1d1168"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "env0_project_id"
+    value               = "43fd4ff1-8d37-4d9d-ac97-295bd850bf94"
+    propagate_at_launch = true
+  }
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/aws_autoscaling_group/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/aws_autoscaling_group/expected/main.tf.bak
@@ -1,0 +1,59 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_placement_group" "test" {
+  name     = "test"
+  strategy = "cluster"
+}
+
+resource "aws_autoscaling_group" "bar" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  initial_lifecycle_hook {
+    name                 = "foobar"
+    default_result       = "CONTINUE"
+    heartbeat_timeout    = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+
+    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
+    role_arn                = "arn:aws:iam::123456789012:role/S3Access"
+  }
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+
+  timeouts {
+    delete = "15m"
+  }
+
+  tag {
+    key                 = "lorem"
+    value               = "ipsum"
+    propagate_at_launch = false
+  }
+}

--- a/test/fixture/terraform_13_14/aws_autoscaling_group/input/main.tf
+++ b/test/fixture/terraform_13_14/aws_autoscaling_group/input/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_placement_group" "test" {
+  name     = "test"
+  strategy = "cluster"
+}
+
+resource "aws_autoscaling_group" "bar" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  initial_lifecycle_hook {
+    name                 = "foobar"
+    default_result       = "CONTINUE"
+    heartbeat_timeout    = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+
+    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
+    role_arn                = "arn:aws:iam::123456789012:role/S3Access"
+  }
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+
+  timeouts {
+    delete = "15m"
+  }
+
+  tag {
+    key                 = "lorem"
+    value               = "ipsum"
+    propagate_at_launch = false
+  }
+}

--- a/test/fixture/terraform_13_14/aws_submodule/expected/child/child.terratag.tf
+++ b/test/fixture/terraform_13_14/aws_submodule/expected/child/child.terratag.tf
@@ -1,0 +1,10 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(map("Name", "Mybucket", "Environment", "Dev"), local.terratag_added_child)
+}
+locals {
+  terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/aws_submodule/expected/child/child.tf.bak
+++ b/test/fixture/terraform_13_14/aws_submodule/expected/child/child.tf.bak
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    "Name"        = "My bucket"
+    "Environment" = "Dev"
+  }
+}

--- a/test/fixture/terraform_13_14/aws_submodule/expected/parent/main.tf
+++ b/test/fixture/terraform_13_14/aws_submodule/expected/parent/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "child-module" {
+  source = "../child"
+}

--- a/test/fixture/terraform_13_14/aws_submodule/input/child/child.tf
+++ b/test/fixture/terraform_13_14/aws_submodule/input/child/child.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    "Name"        = "My bucket"
+    "Environment" = "Dev"
+  }
+}

--- a/test/fixture/terraform_13_14/aws_submodule/input/parent/main.tf
+++ b/test/fixture/terraform_13_14/aws_submodule/input/parent/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "child-module" {
+  source = "../child"
+}

--- a/test/fixture/terraform_13_14/aws_tags_block/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/aws_tags_block/expected/main.terratag.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(map("Name", "Mybucket"), local.terratag_added_main)
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/aws_tags_block/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/aws_tags_block/expected/main.tf.bak
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags {
+    Name        = "My bucket"
+  }
+}

--- a/test/fixture/terraform_13_14/aws_tags_block/input/main.tf
+++ b/test/fixture/terraform_13_14/aws_tags_block/input/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags {
+    Name        = "My bucket"
+  }
+}

--- a/test/fixture/terraform_13_14/aws_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/aws_tags_map/expected/main.terratag.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(map("Name", "Mybucket", "Unquoted1", "Iwannabequoted", "AnotherName", "Yo", "Unquoted2", "Ireallywannabequoted", "Unquoted3", "IreallyreallywannabequotedandIgotacomma", join("-", ["foo", "bar"]), "Testfunction", (local.localTagKey), "Testexpression", "${local.localTagKey2}", "Testvariableaskey", "Yo-${local.localTagKey}", "Testvariableinsidekey", "Testvariableasvalue", "${local.localTagKey}", "Testvariableinsidevalue", "Yo-${local.localTagKey}"), local.terratag_added_main)
+}
+
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(local.localMap, local.terratag_added_main)
+}
+
+locals {
+  localTagKey  = "localTagKey"
+  localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/aws_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/aws_tags_map/expected/main.tf.bak
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    "Name"                    = "My bucket"
+    Unquoted1                 = "I wanna be quoted"
+    "AnotherName"             = "Yo"
+    Unquoted2                 = "I really wanna be quoted"
+    Unquoted3                 = "I really really wanna be quoted and I got a comma",
+    join("-", ["foo", "bar"]) = "Test function"
+    (local.localTagKey)       = "Test expression"
+    "${local.localTagKey2}"   = "Test variable as key"
+    "Yo-${local.localTagKey}" = "Test variable inside key"
+    "Test variable as value" = "${local.localTagKey}"
+    "Test variable inside value"  = "Yo-${local.localTagKey}"
+  }
+}
+
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = local.localMap
+}
+
+locals {
+  localTagKey = "localTagKey"
+  localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
+}

--- a/test/fixture/terraform_13_14/aws_tags_map/input/main.tf
+++ b/test/fixture/terraform_13_14/aws_tags_map/input/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    "Name"                    = "My bucket"
+    Unquoted1                 = "I wanna be quoted"
+    "AnotherName"             = "Yo"
+    Unquoted2                 = "I really wanna be quoted"
+    Unquoted3                 = "I really really wanna be quoted and I got a comma",
+    join("-", ["foo", "bar"]) = "Test function"
+    (local.localTagKey)       = "Test expression"
+    "${local.localTagKey2}"   = "Test variable as key"
+    "Yo-${local.localTagKey}" = "Test variable inside key"
+    "Test variable as value" = "${local.localTagKey}"
+    "Test variable inside value"  = "Yo-${local.localTagKey}"
+  }
+}
+
+resource "aws_s3_bucket" "a" {
+  bucket = "my-another-tf-test-bucket"
+  acl    = "private"
+
+  tags = local.localMap
+}
+
+locals {
+  localTagKey = "localTagKey"
+  localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
+}

--- a/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -1,0 +1,73 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = local.terratag_added_main
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = local.terratag_added_main
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags       = merge(map("existing", "tag"), local.terratag_added_main)
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = merge(map("existing", "tag"), local.terratag_added_main)
+}
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/expected/main.tf.bak
@@ -1,0 +1,68 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}

--- a/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/input/main.tf
+++ b/test/fixture/terraform_13_14/azurerm_kubernetes_cluster/input/main.tf
@@ -1,0 +1,68 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "non_existing_tags_rg" {
+  name     = "non_existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "non_existing_tags_cluster" {
+  name                = "non_existing_tags_cluster"
+  location            = azurerm_resource_group.non_existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.non_existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+}
+
+resource "azurerm_resource_group" "existing_tags_rg" {
+  name     = "existing_tags_rg"
+  location = "northeurope"
+}
+
+resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
+  name                = "existing_tags_cluster"
+  location            = azurerm_resource_group.existing_tags_rg.location
+  resource_group_name = azurerm_resource_group.existing_tags_rg.name
+  dns_prefix          = "test"
+
+  service_principal {
+    client_id     = "id"
+    client_secret = "secret"
+  }
+
+  default_node_pool {
+    name       = "pool"
+    node_count = 2
+    vm_size    = "Standard_D2_v2"
+    tags = {
+      existing = "tag"
+    }
+  }
+
+  network_profile {
+    load_balancer_sku = "Standard"
+    network_plugin    = "kubenet"
+  }
+
+  tags = {
+    existing = "tag"
+  }
+}

--- a/test/fixture/terraform_13_14/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/azurerm_tags_map/expected/main.terratag.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+  tags     = merge(map("oh", "my"), local.terratag_added_main)
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_space       = ["10.0.0.0/16"]
+  tags                = local.terratag_added_main
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/azurerm_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/azurerm_tags_map/expected/main.tf.bak
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+  tags = {
+    "oh" = "my"
+  }
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_space       = ["10.0.0.0/16"]
+}

--- a/test/fixture/terraform_13_14/azurerm_tags_map/input/main.tf
+++ b/test/fixture/terraform_13_14/azurerm_tags_map/input/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+  tags = {
+    "oh" = "my"
+  }
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_space       = ["10.0.0.0/16"]
+}

--- a/test/fixture/terraform_13_14/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/azurestack_tags_map/expected/main.terratag.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    azurestack = {
+      source = "hashicorp/azurestack"
+    }
+  }
+}
+
+resource "azurestack_resource_group" "test" {
+  name     = "production"
+  location = "West US"
+  tags     = local.terratag_added_main
+}
+
+resource "azurestack_virtual_network" "test" {
+  name                = "production-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+
+  tags = local.terratag_added_main
+}
+
+resource "azurestack_virtual_network" "test2" {
+  name                = "production-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+  tags                = merge(map("yo", "ho"), local.terratag_added_main)
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/azurestack_tags_map/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/azurestack_tags_map/expected/main.tf.bak
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    azurestack = {
+      source = "hashicorp/azurestack"
+    }
+  }
+}
+
+resource "azurestack_resource_group" "test" {
+  name     = "production"
+  location = "West US"
+}
+
+resource "azurestack_virtual_network" "test" {
+  name                = "production-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+
+}
+
+resource "azurestack_virtual_network" "test2" {
+  name                = "production-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+  tags = {
+    "yo" = "ho"
+  }
+}

--- a/test/fixture/terraform_13_14/azurestack_tags_map/input/main.tf
+++ b/test/fixture/terraform_13_14/azurestack_tags_map/input/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    azurestack = {
+      source = "hashicorp/azurestack"
+    }
+  }
+}
+
+resource "azurestack_resource_group" "test" {
+  name     = "production"
+  location = "West US"
+}
+
+resource "azurestack_virtual_network" "test" {
+  name                = "production-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+
+}
+
+resource "azurestack_virtual_network" "test2" {
+  name                = "production-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+  tags = {
+    "yo" = "ho"
+  }
+}

--- a/test/fixture/terraform_13_14/git_issue_17__tfschema_provider_not_from_prefix/expected/main.tf
+++ b/test/fixture/terraform_13_14/git_issue_17__tfschema_provider_not_from_prefix/expected/main.tf
@@ -1,0 +1,31 @@
+data "google_billing_account" "account" {
+  provider = google-beta
+  billing_account = "000000-0000000-0000000-000000"
+}
+
+resource "google_billing_budget" "budget" {
+  provider = "google-beta"
+  billing_account = data.google_billing_account.account.id
+  display_name = "Example Billing Budget"
+
+  budget_filter {
+    projects = ["projects/my-project-name"]
+    credit_types_treatment = "EXCLUDE_ALL_CREDITS"
+    services = ["services/24E6-581D-38E5"] # Bigquery
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units = "100000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 0.9
+    spend_basis = "FORECASTED_SPEND"
+  }
+}

--- a/test/fixture/terraform_13_14/git_issue_17__tfschema_provider_not_from_prefix/input/main.tf
+++ b/test/fixture/terraform_13_14/git_issue_17__tfschema_provider_not_from_prefix/input/main.tf
@@ -1,0 +1,31 @@
+data "google_billing_account" "account" {
+  provider = google-beta
+  billing_account = "000000-0000000-0000000-000000"
+}
+
+resource "google_billing_budget" "budget" {
+  provider = "google-beta"
+  billing_account = data.google_billing_account.account.id
+  display_name = "Example Billing Budget"
+
+  budget_filter {
+    projects = ["projects/my-project-name"]
+    credit_types_treatment = "EXCLUDE_ALL_CREDITS"
+    services = ["services/24E6-581D-38E5"] # Bigquery
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units = "100000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 0.9
+    spend_basis = "FORECASTED_SPEND"
+  }
+}

--- a/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/invalid/invalid.tf
+++ b/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/invalid/invalid.tf
@@ -1,0 +1,1 @@
+a b c d e f g

--- a/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/main.terratag.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(map("Name", "Mybucket"), local.terratag_added_main)
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/expected/main.tf.bak
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags {
+    Name        = "My bucket"
+  }
+}

--- a/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/input/invalid/invalid.tf
+++ b/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/input/invalid/invalid.tf
@@ -1,0 +1,1 @@
+a b c d e f g

--- a/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/input/main.tf
+++ b/test/fixture/terraform_13_14/git_issue_43__invalid_tf_files_in_subfolders/input/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags {
+    Name        = "My bucket"
+  }
+}

--- a/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/expected/main.terratag.tf
@@ -1,0 +1,34 @@
+resource "kubernetes_deployment" "audit_server" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    template {
+      metadata {
+        labels = {
+          app = "as"
+        }
+      }
+      spec {
+        container {
+          image = "helloworld"
+          name  = "as"
+        }
+      }
+    }
+    replicas = true ? 0 : (false ? 3 : 4)
+    strategy {
+      type = "Recreate"
+    }
+  }
+}
+
+resource "google_pubsub_topic" "audit_topic" {
+  name   = "yuvu"
+  labels = merge(local.terratag_added_main, local.terratag_added_main)
+}
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/expected/main.tf.bak
@@ -1,0 +1,29 @@
+resource "kubernetes_deployment" "audit_server" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    template {
+      metadata {
+        labels = {
+          app = "as"
+        }
+      }
+      spec {
+        container {
+          image = "helloworld"
+          name  = "as"
+        }
+      }
+    }
+    replicas = true ? 0 : (false ? 3 : 4)
+    strategy {
+      type = "Recreate"
+    }
+  }
+}
+
+resource "google_pubsub_topic" "audit_topic" {
+  name = "yuvu"
+  labels = local.terratag_added_main
+}

--- a/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/input/main.tf
+++ b/test/fixture/terraform_13_14/git_issue_56__line_ends_with_closing_paren/input/main.tf
@@ -1,0 +1,29 @@
+resource "kubernetes_deployment" "audit_server" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    template {
+      metadata {
+        labels = {
+          app = "as"
+        }
+      }
+      spec {
+        container {
+          image = "helloworld"
+          name  = "as"
+        }
+      }
+    }
+    replicas = true ? 0 : (false ? 3 : 4)
+    strategy {
+      type = "Recreate"
+    }
+  }
+}
+
+resource "google_pubsub_topic" "audit_topic" {
+  name = "yuvu"
+  labels = local.terratag_added_main
+}

--- a/test/fixture/terraform_13_14/git_issue_66_aws_aliased_provider/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/git_issue_66_aws_aliased_provider/expected/main.terratag.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "custom"
+  version = "~> 3.0"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  provider = aws.custom
+
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+  tags   = local.terratag_added_main
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/git_issue_66_aws_aliased_provider/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/git_issue_66_aws_aliased_provider/expected/main.tf.bak
@@ -1,0 +1,12 @@
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "custom"
+  version = "~> 3.0"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  provider = aws.custom
+
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+}

--- a/test/fixture/terraform_13_14/git_issue_66_aws_aliased_provider/input/main.tf
+++ b/test/fixture/terraform_13_14/git_issue_66_aws_aliased_provider/input/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "custom"
+  version = "~> 3.0"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  provider = aws.custom
+
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+}

--- a/test/fixture/terraform_13_14/google_beta_resource_skip/expected/main.tf
+++ b/test/fixture/terraform_13_14/google_beta_resource_skip/expected/main.tf
@@ -1,0 +1,43 @@
+// This resource should be skipped, as tfschema won't find resources that are exclusive to google-beta
+// Note the google provider must be present in addition to the google-beta one
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+    }
+  }
+}
+
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+
+provider "google-beta" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+
+data "google_billing_account" "account" {
+  provider = google-beta
+  billing_account = "000000-0000000-0000000-000000"
+}
+
+resource "google_billing_budget" "budget" {
+  provider = google-beta
+  billing_account = data.google_billing_account.account.id
+  display_name = "Example Billing Budget"
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units = "100000"
+    }
+  }
+  threshold_rules {
+    threshold_percent =  0.5
+  }
+}

--- a/test/fixture/terraform_13_14/google_beta_resource_skip/input/main.tf
+++ b/test/fixture/terraform_13_14/google_beta_resource_skip/input/main.tf
@@ -1,0 +1,43 @@
+// This resource should be skipped, as tfschema won't find resources that are exclusive to google-beta
+// Note the google provider must be present in addition to the google-beta one
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+    }
+  }
+}
+
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+
+provider "google-beta" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+
+data "google_billing_account" "account" {
+  provider = google-beta
+  billing_account = "000000-0000000-0000000-000000"
+}
+
+resource "google_billing_budget" "budget" {
+  provider = google-beta
+  billing_account = data.google_billing_account.account.id
+  display_name = "Example Billing Budget"
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units = "100000"
+    }
+  }
+  threshold_rules {
+    threshold_percent =  0.5
+  }
+}

--- a/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+resource "google_container_cluster" "no-labels-cluster" {
+  name     = "cluster"
+  location = "us-central1"
+
+  node_config {
+    machine_type = "n1-standard-1"
+  }
+
+  node_pool {
+    node_config {
+      machine_type = "n1-standard-1"
+    }
+  }
+  resource_labels = local.terratag_added_main
+}
+
+resource "google_container_node_pool" "no-labels-pool" {
+  cluster = google_container_cluster.no-labels-cluster.name
+
+  node_config {
+    machine_type = "n1-standard-1"
+  }
+}
+
+resource "google_container_cluster" "existing-labels-cluster" {
+  name     = "cluster2"
+  location = "us-central1"
+
+  resource_labels = merge(map("foo", "bar"), local.terratag_added_main)
+
+  node_config {
+    machine_type = "n1-standard-1"
+    labels = {
+      foo = "bar"
+    }
+  }
+
+  node_pool {
+    node_config {
+      machine_type = "n1-standard-1"
+      labels = {
+        foo = "bar"
+      }
+    }
+  }
+}
+
+resource "google_container_node_pool" "existing-labels-pool" {
+  cluster = google_container_cluster.existing-labels-cluster.name
+
+  node_config {
+    machine_type = "n1-standard-1"
+    labels = {
+      foo = "bar"
+    }
+  }
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/google_container_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/google_container_cluster/expected/main.tf.bak
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+resource "google_container_cluster" "no-labels-cluster" {
+  name = "cluster"
+  location = "us-central1"
+
+  node_config {
+    machine_type = "n1-standard-1"
+  }
+
+  node_pool {
+    node_config {
+      machine_type = "n1-standard-1"
+    }
+  }
+}
+
+resource "google_container_node_pool" "no-labels-pool" {
+  cluster = google_container_cluster.no-labels-cluster.name
+
+  node_config {
+    machine_type = "n1-standard-1"
+  }
+}
+
+resource "google_container_cluster" "existing-labels-cluster" {
+  name = "cluster2"
+  location = "us-central1"
+
+  resource_labels = {
+    foo = "bar"
+  }
+
+  node_config {
+    machine_type = "n1-standard-1"
+    labels = {
+      foo = "bar"
+    }
+  }
+
+  node_pool {
+    node_config {
+      machine_type = "n1-standard-1"
+      labels = {
+        foo = "bar"
+      }
+    }
+  }
+}
+
+resource "google_container_node_pool" "existing-labels-pool" {
+  cluster = google_container_cluster.existing-labels-cluster.name
+
+  node_config {
+    machine_type = "n1-standard-1"
+    labels = {
+      foo = "bar"
+    }
+  }
+}

--- a/test/fixture/terraform_13_14/google_container_cluster/input/main.tf
+++ b/test/fixture/terraform_13_14/google_container_cluster/input/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+resource "google_container_cluster" "no-labels-cluster" {
+  name = "cluster"
+  location = "us-central1"
+
+  node_config {
+    machine_type = "n1-standard-1"
+  }
+
+  node_pool {
+    node_config {
+      machine_type = "n1-standard-1"
+    }
+  }
+}
+
+resource "google_container_node_pool" "no-labels-pool" {
+  cluster = google_container_cluster.no-labels-cluster.name
+
+  node_config {
+    machine_type = "n1-standard-1"
+  }
+}
+
+resource "google_container_cluster" "existing-labels-cluster" {
+  name = "cluster2"
+  location = "us-central1"
+
+  resource_labels = {
+    foo = "bar"
+  }
+
+  node_config {
+    machine_type = "n1-standard-1"
+    labels = {
+      foo = "bar"
+    }
+  }
+
+  node_pool {
+    node_config {
+      machine_type = "n1-standard-1"
+      labels = {
+        foo = "bar"
+      }
+    }
+  }
+}
+
+resource "google_container_node_pool" "existing-labels-pool" {
+  cluster = google_container_cluster.existing-labels-cluster.name
+
+  node_config {
+    machine_type = "n1-standard-1"
+    labels = {
+      foo = "bar"
+    }
+  }
+}

--- a/test/fixture/terraform_13_14/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/google_labels_map/expected/main.terratag.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+resource "google_storage_bucket" "static-site" {
+  name          = "image-store.com"
+  location      = "EU"
+  force_destroy = true
+
+  bucket_policy_only = true
+
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "404.html"
+  }
+  cors {
+    origin          = ["http://image-store.com"]
+    method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+  labels = merge(map("foo", "bar"), local.terratag_added_main)
+}
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_13_14/google_labels_map/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/google_labels_map/expected/main.tf.bak
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+resource "google_storage_bucket" "static-site" {
+  name          = "image-store.com"
+  location      = "EU"
+  force_destroy = true
+
+  bucket_policy_only = true
+
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "404.html"
+  }
+  cors {
+    origin          = ["http://image-store.com"]
+    method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+  labels = {
+    "foo" = "bar"
+  }
+}

--- a/test/fixture/terraform_13_14/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_13_14/google_labels_map/input/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+resource "google_storage_bucket" "static-site" {
+  name          = "image-store.com"
+  location      = "EU"
+  force_destroy = true
+
+  bucket_policy_only = true
+
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "404.html"
+  }
+  cors {
+    origin          = ["http://image-store.com"]
+    method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+  labels = {
+    "foo" = "bar"
+  }
+}


### PR DESCRIPTION
The integration tests for TF 13 and 14 were mistakenly removed in https://github.com/env0/terratag/pull/84.

Re-add them.
All I did was simply to checkout the `test/fixtures/terraform_13_14` folder from the commit prior to the merge of the mentioned PR