### PR TITLE
Support filtering by resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# [<img src="ttlogo.png" width="300" alt="Terratag Logo">](https://terratag.io) 
+# [<img src="ttlogo.png" width="300" alt="Terratag Logo">](https://terratag.io)
 [![ci](https://github.com/env0/terratag/workflows/ci/badge.svg)](https://github.com/env0/terratag/actions?query=workflow%3Aci+branch%3Amaster) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fenv0%2Fterratag.svg?type=small)](https://app.fossa.com/projects/git%2Bgithub.com%2Fenv0%2Fterratag?ref=badge_small)
 
-> <sub>Terratag is brought to you with&nbsp;❤️&nbsp; by   
->[<img src="logo.svg" width="150">](https://env0.com)  
-> Let your team manage their own environment in AWS, Azure and Google. <br/> 
-> Governed by your policies and with complete visibility and cost management.      
+> <sub>Terratag is brought to you with&nbsp;❤️&nbsp; by
+>[<img src="logo.svg" width="150">](https://env0.com)
+> Let your team manage their own environment in AWS, Azure and Google. <br/>
+> Governed by your policies and with complete visibility and cost management.
 
 ## What?
-Terratag is a CLI tool allowing for tags or labels to be applied across an entire set of Terraform files. Terratag will apply tags or labels to any AWS, GCP and Azure resources. 
+Terratag is a CLI tool allowing for tags or labels to be applied across an entire set of Terraform files. Terratag will apply tags or labels to any AWS, GCP and Azure resources.
 
 ### Terratag in action
 ![](https://assets.website-files.com/5dc3f52851595b160ba99670/5f62090d2d532ca35e143133_terratag.gif)
@@ -27,18 +27,19 @@ Maintaining tags across your application is hard, especially when done manually.
     Or download the latest [release binary](https://github.com/env0/terratag/releases) .
 
 1. Initialize Terraform modules to get provider schema and pull child modules:
-   ```bash    
-    terraform init  
+   ```bash
+    terraform init
     ```
-1. Run Terratag  
-      ```bash    
+1. Run Terratag
+      ```bash
        terratag -dir=foo/bar -tags={\"environment_id\": \"prod\"}
-   ```    
-   
-   Terratag supports the following arguments:  
-   - `-dir` - optional, the directory to recursively search for any `.tf` file and try to terratag it.  
+   ```
+
+   Terratag supports the following arguments:
+   - `-dir` - optional, the directory to recursively search for any `.tf` file and try to terratag it.
    - `-tags` - tags, as valid JSON (NOT HCL)
    - `-skipTerratagFiles` - optional. Default to `true`. Skips any previously tagged - (files with `terratag.tf` suffix)
+   - `-filter` - optional. Only apply tags to the selected resource types (comma separated list)
 
 ### Example Output
 #### Before Terratag
@@ -148,6 +149,7 @@ locals {
 * `-skipTerratagFiles=false` - Dont skip processing `*.terratag.tf` files (when running terratag a second time for the same directory)
 * `-verbose=true` - Turn on verbose logging
 * `-rename=false` - Instead of replacing files named `<basename>.tf` with `<basename>.terratag.tf`, keep the original filename
+* `-filter=<type_1>,<type_2>` - Only apply tags to the selected resource types
 
 ##### See more samples [here](https://github.com/env0/terratag/tree/master/test/fixture)
 
@@ -155,7 +157,7 @@ locals {
 - Resources already having the exact same tag as the one being appended will be overridden
 
 ## Develop
-Issues and Pull Requests are very welcome!  
+Issues and Pull Requests are very welcome!
 
 ### Prerequisites
 - Go > 1.13.5
@@ -170,8 +172,8 @@ go build
 ### Test
 
 #### Structure
-The test suite will look for fixtures under `test/fixtures/terraform_xx`.  
-Each fixture placed there should have the following directory structure:  
+The test suite will look for fixtures under `test/fixtures/terraform_xx`.
+Each fixture placed there should have the following directory structure:
 ```
 my_fixture
 |+ input
@@ -180,23 +182,23 @@ my_fixture
 |- expected
 ```
 
-- `input` is where you should place the terraform files of your fixture.  
-All commands will be executed wherever down the hierarchy where `main.tf` is located.  
-We do that to allow cases where complex nested submodule resolution may take place, and one would like to test how a directory higher up the hierarchy gets resolved.  
+- `input` is where you should place the terraform files of your fixture.
+All commands will be executed wherever down the hierarchy where `main.tf` is located.
+We do that to allow cases where complex nested submodule resolution may take place, and one would like to test how a directory higher up the hierarchy gets resolved.
 - `expected` is a directory in which all `.terratag.tf` files will be matched with the output directory
 
 #### What's being tested?
 Each test will run:
 - `terraform init`
 - `terratag`
-- `terraform validate`  
+- `terraform validate`
 
-And finally, will compare the results in `out` with the `expected` directory 
+And finally, will compare the results in `out` with the `expected` directory
 
 #### Running Tests
-Tests can only run on a specific Terraform version - 
+Tests can only run on a specific Terraform version -
 ```
 go test -run TestTerraformXX
-``` 
+```
 
 We use [tfenv](https://github.com/tfutils/tfenv) to switch between versions. The exact versions used in the CI tests can be found under `test/tfenvconf`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Maintaining tags across your application is hard, especially when done manually.
    - `-dir` - optional, the directory to recursively search for any `.tf` file and try to terratag it.
    - `-tags` - tags, as valid JSON (NOT HCL)
    - `-skipTerratagFiles` - optional. Default to `true`. Skips any previously tagged - (files with `terratag.tf` suffix)
-   - `-filter` - optional. Only apply tags to the selected resource types (comma separated list)
+   - `-filter` - optional. Only apply tags to the selected resource types (regex)
 
 ### Example Output
 #### Before Terratag
@@ -149,7 +149,7 @@ locals {
 * `-skipTerratagFiles=false` - Dont skip processing `*.terratag.tf` files (when running terratag a second time for the same directory)
 * `-verbose=true` - Turn on verbose logging
 * `-rename=false` - Instead of replacing files named `<basename>.tf` with `<basename>.terratag.tf`, keep the original filename
-* `-filter=<type_1>,<type_2>` - Only apply tags to the selected resource types
+* `-filter=<regular expression>` - defaults to `.*`. Only apply tags to the resource types matched by the regular expression
 
 ##### See more samples [here](https://github.com/env0/terratag/tree/master/test/fixture)
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,7 +14,7 @@ type Args struct {
 	Tags                string
 	Dir                 string
 	SkipTerratagFiles   string
-	Filter              []string
+	Filter              string
 	IsSkipTerratagFiles bool
 	Verbose             bool
 	Rename              bool
@@ -27,7 +27,7 @@ func InitArgs() (Args, bool) {
 	args.Tags = setFlag("tags", "")
 	args.Dir = setFlag("dir", ".")
 	args.IsSkipTerratagFiles = booleanFlag("skipTerratagFiles", true)
-	args.Filter = setArrayFlag("filter", make([]string, 0))
+	args.Filter = setFlag("filter", ".*")
 	args.Verbose = booleanFlag("verbose", false)
 	args.Rename = booleanFlag("rename", true)
 
@@ -45,18 +45,6 @@ func setFlag(flag string, defaultValue string) string {
 	for _, arg := range os.Args {
 		if strings.HasPrefix(arg, prefix) {
 			result = strings.TrimPrefix(arg, prefix)
-		}
-	}
-
-	return result
-}
-
-func setArrayFlag(flag string, defaultValue []string) []string {
-	result := defaultValue
-	prefix := "-" + flag + "="
-	for _, arg := range os.Args {
-		if strings.HasPrefix(arg, prefix) {
-			result = strings.Split(strings.TrimPrefix(arg, prefix), ",")
 		}
 	}
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,6 +14,7 @@ type Args struct {
 	Tags                string
 	Dir                 string
 	SkipTerratagFiles   string
+	Filter              []string
 	IsSkipTerratagFiles bool
 	Verbose             bool
 	Rename              bool
@@ -26,6 +27,7 @@ func InitArgs() (Args, bool) {
 	args.Tags = setFlag("tags", "")
 	args.Dir = setFlag("dir", ".")
 	args.IsSkipTerratagFiles = booleanFlag("skipTerratagFiles", true)
+	args.Filter = setArrayFlag("filter", make([]string, 0))
 	args.Verbose = booleanFlag("verbose", false)
 	args.Rename = booleanFlag("rename", true)
 
@@ -43,6 +45,18 @@ func setFlag(flag string, defaultValue string) string {
 	for _, arg := range os.Args {
 		if strings.HasPrefix(arg, prefix) {
 			result = strings.TrimPrefix(arg, prefix)
+		}
+	}
+
+	return result
+}
+
+func setArrayFlag(flag string, defaultValue []string) []string {
+	result := defaultValue
+	prefix := "-" + flag + "="
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, prefix) {
+			result = strings.Split(strings.TrimPrefix(arg, prefix), ",")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -152,12 +152,3 @@ func jsonToHclMap(tags string) string {
 	}
 	return "{" + strings.Join(mapContent, ",") + "}"
 }
-
-func contains(array []string, value string) bool {
-	for _, item := range array {
-		if item == value {
-			return true
-		}
-	}
-	return false
-}

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -52,7 +52,7 @@ func TestTerraform1o0(t *testing.T) {
 }
 
 func TestTerraform1o0WithFilter(t *testing.T) {
-	testTerraformWithFilter(t, "15_1.0_filter", "azurerm_resource_group,aws_s3_bucket")
+	testTerraformWithFilter(t, "15_1.0_filter", "azurerm_resource_group|aws_s3_bucket")
 }
 
 func testTerraform(t *testing.T, version string) {

--- a/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.terratag.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+  tags = merge(tomap({
+    "oh" = "my"
+  }), local.terratag_added_main)
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(tomap({
+    "Name" = "My bucket"
+  }), local.terratag_added_main)
+}
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}

--- a/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.terratag.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "azurerm_resource_group" "example" {
+resource "azurerm_resource_group" "should_have_tags" {
   name     = "example-resources"
   location = "West Europe"
   tags = merge(tomap({
@@ -26,14 +26,14 @@ resource "azurerm_resource_group" "example" {
   }), local.terratag_added_main)
 }
 
-resource "azurerm_virtual_network" "example" {
+resource "azurerm_virtual_network" "should_not_have_tags" {
   name                = "example-network"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.should_have_tags.name
+  location            = azurerm_resource_group.should_have_tags.location
   address_space       = ["10.0.0.0/16"]
 }
 
-resource "aws_s3_bucket" "b" {
+resource "aws_s3_bucket" "should_have_tags" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 

--- a/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.tf.bak
+++ b/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.tf.bak
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+  tags = {
+    "oh" = "my"
+  }
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags {
+    Name = "My bucket"
+  }
+}

--- a/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.tf.bak
+++ b/test/fixture/terraform_15_1.0_filter/aws_azure/expected/main.tf.bak
@@ -18,7 +18,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "azurerm_resource_group" "example" {
+resource "azurerm_resource_group" "should_have_tags" {
   name     = "example-resources"
   location = "West Europe"
   tags = {
@@ -26,14 +26,14 @@ resource "azurerm_resource_group" "example" {
   }
 }
 
-resource "azurerm_virtual_network" "example" {
+resource "azurerm_virtual_network" "should_not_have_tags" {
   name                = "example-network"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.should_have_tags.name
+  location            = azurerm_resource_group.should_have_tags.location
   address_space       = ["10.0.0.0/16"]
 }
 
-resource "aws_s3_bucket" "b" {
+resource "aws_s3_bucket" "should_have_tags" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 

--- a/test/fixture/terraform_15_1.0_filter/aws_azure/input/main.tf
+++ b/test/fixture/terraform_15_1.0_filter/aws_azure/input/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+  tags = {
+    "oh" = "my"
+  }
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags {
+    Name = "My bucket"
+  }
+}

--- a/test/fixture/terraform_15_1.0_filter/aws_azure/input/main.tf
+++ b/test/fixture/terraform_15_1.0_filter/aws_azure/input/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "azurerm_resource_group" "example" {
+resource "azurerm_resource_group" "should_have_tags" {
   name     = "example-resources"
   location = "West Europe"
   tags = {
@@ -26,14 +26,14 @@ resource "azurerm_resource_group" "example" {
   }
 }
 
-resource "azurerm_virtual_network" "example" {
+resource "azurerm_virtual_network" "should_not_have_tags" {
   name                = "example-network"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.should_have_tags.name
+  location            = azurerm_resource_group.should_have_tags.location
   address_space       = ["10.0.0.0/16"]
 }
 
-resource "aws_s3_bucket" "b" {
+resource "aws_s3_bucket" "should_have_tags" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 


### PR DESCRIPTION
Adds a new flag `-filter` so that only the specified resource types will have tags applied.