### PR TITLE
Rewrite package terratag/cli

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -18,8 +18,10 @@ type Args struct {
 func InitArgs() (Args, bool) {
 	args := Args{}
 	isMissingArg := false
+	programName := os.Args[0]
+	programArgs := os.Args[1:]
 
-	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs := flag.NewFlagSet(programName, flag.ExitOnError)
 
 	fs.StringVar(&args.Tags, "tags", "", "Tags as a valid JSON document")
 	fs.StringVar(&args.Dir, "dir", ".", "Directory to recursively search for .tf files and terratag them")
@@ -28,7 +30,7 @@ func InitArgs() (Args, bool) {
 	fs.BoolVar(&args.Verbose, "verbose", false, "Enable verbose logging")
 	fs.BoolVar(&args.Rename, "rename", true, "Keep the original filename or replace it with <basename>.terratag.tf")
 
-	fs.Parse(os.Args[1:])
+	fs.Parse(programArgs)
 
 	if args.Tags == "" {
 		log.Println("Usage: terratag -tags='{ \"some_tag\": \"value\" }' [-dir=\".\"]")

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,19 +1,14 @@
 package cli
 
 import (
-	"fmt"
+	"flag"
 	"log"
 	"os"
-	"strconv"
-	"strings"
-
-	"github.com/env0/terratag/errors"
 )
 
 type Args struct {
 	Tags                string
 	Dir                 string
-	SkipTerratagFiles   string
 	Filter              string
 	IsSkipTerratagFiles bool
 	Verbose             bool
@@ -24,12 +19,16 @@ func InitArgs() (Args, bool) {
 	args := Args{}
 	isMissingArg := false
 
-	args.Tags = setFlag("tags", "")
-	args.Dir = setFlag("dir", ".")
-	args.IsSkipTerratagFiles = booleanFlag("skipTerratagFiles", true)
-	args.Filter = setFlag("filter", ".*")
-	args.Verbose = booleanFlag("verbose", false)
-	args.Rename = booleanFlag("rename", true)
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&args.Tags, "tags", "", "Tags as a valid JSON document")
+	fs.StringVar(&args.Dir, "dir", ".", "Directory to recursively search for .tf files and terratag them")
+	fs.BoolVar(&args.IsSkipTerratagFiles, "skipTerratagFiles", true, "Skips any previously tagged files")
+	fs.StringVar(&args.Filter, "filter", ".*", "Only apply tags to the selected resource types (regex)")
+	fs.BoolVar(&args.Verbose, "verbose", false, "Enable verbose logging")
+	fs.BoolVar(&args.Rename, "rename", true, "Keep the original filename or replace it with <basename>.terratag.tf")
+
+	fs.Parse(os.Args[1:])
 
 	if args.Tags == "" {
 		log.Println("Usage: terratag -tags='{ \"some_tag\": \"value\" }' [-dir=\".\"]")
@@ -37,28 +36,4 @@ func InitArgs() (Args, bool) {
 	}
 
 	return args, isMissingArg
-}
-
-func setFlag(flag string, defaultValue string) string {
-	result := defaultValue
-	prefix := "-" + flag + "="
-	for _, arg := range os.Args {
-		if strings.HasPrefix(arg, prefix) {
-			result = strings.TrimPrefix(arg, prefix)
-		}
-	}
-
-	return result
-}
-
-func booleanFlag(flag string, defaultValue bool) bool {
-	defaultString := "false"
-	if defaultValue {
-		defaultString = "true"
-	}
-	stringValue := setFlag(flag, defaultString)
-	value, err := strconv.ParseBool(stringValue)
-	errorMessage := fmt.Sprint("-", flag, " may only be set to true or false")
-	errors.PanicOnError(err, &errorMessage)
-	return value
 }

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 var cleanArgs = append(os.Args)
-
+var programName = os.Args[0]
 var args = []string{
-	os.Args[0],
+	programName,
 	"-tags={\"env0_environment_id\":\"40907eff-cf7c-419a-8694-e1c6bf1d1168\",\"env0_project_id\":\"43fd4ff1-8d37-4d9d-ac97-295bd850bf94\"}",
 }
 var rootDir = "test/fixture"

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -18,7 +18,11 @@ import (
 )
 
 var cleanArgs = append(os.Args)
-var args = append(os.Args, "-tags={\"env0_environment_id\":\"40907eff-cf7c-419a-8694-e1c6bf1d1168\",\"env0_project_id\":\"43fd4ff1-8d37-4d9d-ac97-295bd850bf94\"}")
+
+var args = []string{
+	os.Args[0],
+	"-tags={\"env0_environment_id\":\"40907eff-cf7c-419a-8694-e1c6bf1d1168\",\"env0_project_id\":\"43fd4ff1-8d37-4d9d-ac97-295bd850bf94\"}",
+}
 var rootDir = "test/fixture"
 
 type TestCase struct {


### PR DESCRIPTION
Hi there,

With this PR I would love to propose a small improvement for the terratag/cli package.
Instead of writing your own functions to manage CLI arguments, you can use the package 'flag' from the standard Golang library.

One of the benefits of using the package 'flag' is that it is coming with the build-in "help", it is done transparently by the package. Here is how it looks:

```
# terratag -help
Usage of terratag:
  -dir string
    	Directory to recursively search for .tf files and terratag them (default ".")
  -filter string
    	Only apply tags to the selected resource types (regex) (default ".*")
  -rename
    	Keep the original filename or replace it with <basename>.terratag.tf (default true)
  -skipTerratagFiles
    	Skips any previously tagged files (default true)
  -tags string
    	Tags as a valid JSON document
  -verbose
    	Enable verbose logging
```

Another benefit is the build-in check for the parameters of the argument:
```
# terratag -verbose=hello                                                                                                                               6s
invalid boolean value "hello" for -verbose: parse error
```

I am not sure if the descriptions for the options are right, please feel free to update them.

Thank you.