### PR TITLE
More robust Terraform version parsing

### DIFF
--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
+	"regexp"
 
 	"github.com/bmatcuk/doublestar"
 	"github.com/env0/terratag/errors"
@@ -23,8 +23,9 @@ func GetTerraformVersion() convert.Version {
 	outputAsString := strings.TrimSpace(string(output))
 	errors.PanicOnError(err, &outputAsString)
 
-	regexp.MustCompile(`Terraform v(\d+)\.(\d+)\.\d+`)
-	matches := strings.Split(strings.TrimPrefix(strings.TrimSpace(outputAsString), "Terraform v"), ".")
+	regularExpression := regexp.MustCompile(`Terraform v(\d+).(\d+)\.\d+`)
+	matches := regularExpression.FindStringSubmatch(outputAsString)[1:]
+
 	if matches == nil {
 		log.Fatalln("Unable to parse 'terraform version'")
 		return convert.Version{}


### PR DESCRIPTION
Fixes #89 

The output of `terraform version` does not have to start with `Terraform`, if executed e.g. inside Github Actions environment. Use regex-based matching to avoid this pitfall.