### PR TITLE
Fix: skip azurerm_api_management_named_value resources

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 )
 
+var resourcesToSkip = []string{"azurerm_api_management_named_value"}
+
 func getProviderByResource(resourceType string) Provider {
 	if strings.HasPrefix(resourceType, "aws_") {
 		return "aws"
@@ -39,6 +41,12 @@ func GetTagIdByResource(resourceType string) string {
 }
 
 func IsSupportedResource(resourceType string) bool {
+	for _, resourceToSkip := range resourcesToSkip {
+		if resourceType == resourceToSkip {
+			return false
+		}
+	}
+
 	return isSupportedProvider(getProviderByResource(resourceType))
 }
 

--- a/test/fixture/terraform_15_1.0/azurerm_api_management_named_value/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0/azurerm_api_management_named_value/expected/main.terratag.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "group" {
+  name     = "group0"
+  location = "West Europe"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_api_management" "api_mngmt" {
+  name                = "api0"
+  location            = azurerm_resource_group.group.location
+  resource_group_name = azurerm_resource_group.group.name
+  publisher_name      = "publisher"
+  publisher_email     = "publisher@env0.com"
+
+  sku_name = "Developer_1"
+  tags     = local.terratag_added_main
+}
+
+resource "azurerm_api_management_named_value" "api_mngmt_named_value" {
+  name                = "value0"
+  resource_group_name = azurerm_resource_group.group.name
+  api_management_name = azurerm_api_management.api_mngmt.name
+  display_name        = "name"
+  value               = "value"
+}
+
+locals {
+  terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}
+

--- a/test/fixture/terraform_15_1.0/azurerm_api_management_named_value/expected/main.tf.bak
+++ b/test/fixture/terraform_15_1.0/azurerm_api_management_named_value/expected/main.tf.bak
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "group" {
+  name     = "group0"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "api_mngmt" {
+  name                = "api0"
+  location            = azurerm_resource_group.group.location
+  resource_group_name = azurerm_resource_group.group.name
+  publisher_name      = "publisher"
+  publisher_email     = "publisher@env0.com"
+
+  sku_name = "Developer_1"
+}
+
+resource "azurerm_api_management_named_value" "api_mngmt_named_value" {
+  name                = "value0"
+  resource_group_name = azurerm_resource_group.group.name
+  api_management_name = azurerm_api_management.api_mngmt.name
+  display_name        = "name"
+  value               = "value"
+}

--- a/test/fixture/terraform_15_1.0/azurerm_api_management_named_value/input/main.tf
+++ b/test/fixture/terraform_15_1.0/azurerm_api_management_named_value/input/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "group" {
+  name     = "group0"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "api_mngmt" {
+  name                = "api0"
+  location            = azurerm_resource_group.group.location
+  resource_group_name = azurerm_resource_group.group.name
+  publisher_name      = "publisher"
+  publisher_email     = "publisher@env0.com"
+
+  sku_name = "Developer_1"
+}
+
+resource "azurerm_api_management_named_value" "api_mngmt_named_value" {
+  name                = "value0"
+  resource_group_name = azurerm_resource_group.group.name
+  api_management_name = azurerm_api_management.api_mngmt.name
+  display_name        = "name"
+  value               = "value"
+}


### PR DESCRIPTION
Fixes #103 
This PR adds an ability to skip specific resources by their type