### PR TITLE
Fix: google related test fixtures

### DIFF
--- a/test/fixture/terraform_11/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/google_container_cluster/expected/main.terratag.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "2.20.3"
+}
+
 resource "google_container_cluster" "no-labels-cluster" {
   name     = "cluster"
   location = "us-central1"
@@ -55,6 +59,7 @@ resource "google_container_node_pool" "existing-labels-pool" {
     }
   }
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_11/google_container_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_11/google_container_cluster/expected/main.tf.bak
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "2.20.3"
+}
+
 resource "google_container_cluster" "no-labels-cluster" {
   name = "cluster"
   location = "us-central1"

--- a/test/fixture/terraform_11/google_container_cluster/input/main.tf
+++ b/test/fixture/terraform_11/google_container_cluster/input/main.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "2.20.3"
+}
+
 resource "google_container_cluster" "no-labels-cluster" {
   name = "cluster"
   location = "us-central1"

--- a/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "2.20.3"
+}
+
 resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"
@@ -15,6 +19,7 @@ resource "google_storage_bucket" "static-site" {
   }
   labels = "${merge(map("foo", "bar"), local.terratag_added_main)}"
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_11/google_labels_map/expected/main.terratag.tf
@@ -3,8 +3,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"

--- a/test/fixture/terraform_11/google_labels_map/expected/main.tf.bak
+++ b/test/fixture/terraform_11/google_labels_map/expected/main.tf.bak
@@ -3,8 +3,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"

--- a/test/fixture/terraform_11/google_labels_map/expected/main.tf.bak
+++ b/test/fixture/terraform_11/google_labels_map/expected/main.tf.bak
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "2.20.3"
+}
+
 resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"

--- a/test/fixture/terraform_11/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_11/google_labels_map/input/main.tf
@@ -3,8 +3,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"

--- a/test/fixture/terraform_11/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_11/google_labels_map/input/main.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "2.20.3"
+}
+
 resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"

--- a/test/fixture/terraform_12/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/google_container_cluster/expected/main.terratag.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "3.65.0"
+}
+
 resource "google_container_cluster" "no-labels-cluster" {
   name     = "cluster"
   location = "us-central1"
@@ -55,6 +59,7 @@ resource "google_container_node_pool" "existing-labels-pool" {
     }
   }
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_12/google_container_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_12/google_container_cluster/expected/main.tf.bak
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "3.65.0"
+}
+
 resource "google_container_cluster" "no-labels-cluster" {
   name = "cluster"
   location = "us-central1"

--- a/test/fixture/terraform_12/google_container_cluster/input/main.tf
+++ b/test/fixture/terraform_12/google_container_cluster/input/main.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "3.65.0"
+}
+
 resource "google_container_cluster" "no-labels-cluster" {
   name = "cluster"
   location = "us-central1"

--- a/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "3.65.0"
+}
+
 resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"
@@ -15,6 +19,7 @@ resource "google_storage_bucket" "static-site" {
   }
   labels = merge(map("foo", "bar"), local.terratag_added_main)
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_12/google_labels_map/expected/main.terratag.tf
@@ -3,8 +3,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"

--- a/test/fixture/terraform_12/google_labels_map/expected/main.tf.bak
+++ b/test/fixture/terraform_12/google_labels_map/expected/main.tf.bak
@@ -3,8 +3,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"

--- a/test/fixture/terraform_12/google_labels_map/expected/main.tf.bak
+++ b/test/fixture/terraform_12/google_labels_map/expected/main.tf.bak
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "3.65.0"
+}
+
 resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"

--- a/test/fixture/terraform_12/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_12/google_labels_map/input/main.tf
@@ -3,8 +3,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"

--- a/test/fixture/terraform_12/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_12/google_labels_map/input/main.tf
@@ -1,3 +1,7 @@
+provider "google" {
+  version = "3.65.0"
+}
+
 resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"

--- a/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/google_container_cluster/expected/main.terratag.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "4.1.0"
     }
   }
@@ -64,6 +64,7 @@ resource "google_container_node_pool" "existing-labels-pool" {
     }
   }
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_13_14/google_container_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/google_container_cluster/expected/main.tf.bak
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_13_14/google_container_cluster/input/main.tf
+++ b/test/fixture/terraform_13_14/google_container_cluster/input/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_13_14/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_13_14/google_labels_map/expected/main.terratag.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }
@@ -10,8 +11,6 @@ resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"
   force_destroy = true
-
-  bucket_policy_only = true
 
   website {
     main_page_suffix = "index.html"
@@ -25,6 +24,7 @@ resource "google_storage_bucket" "static-site" {
   }
   labels = merge(map("foo", "bar"), local.terratag_added_main)
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_13_14/google_labels_map/expected/main.tf.bak
+++ b/test/fixture/terraform_13_14/google_labels_map/expected/main.tf.bak
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }
@@ -10,8 +11,6 @@ resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"
   force_destroy = true
-
-  bucket_policy_only = true
 
   website {
     main_page_suffix = "index.html"

--- a/test/fixture/terraform_13_14/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_13_14/google_labels_map/input/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_13_14/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_13_14/google_labels_map/input/main.tf
@@ -11,8 +11,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"

--- a/test/fixture/terraform_15_1.0/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0/google_container_cluster/expected/main.terratag.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_15_1.0/google_container_cluster/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0/google_container_cluster/expected/main.terratag.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "4.1.0"
     }
   }
@@ -66,6 +66,7 @@ resource "google_container_node_pool" "existing-labels-pool" {
     }
   }
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_15_1.0/google_container_cluster/expected/main.tf.bak
+++ b/test/fixture/terraform_15_1.0/google_container_cluster/expected/main.tf.bak
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_15_1.0/google_container_cluster/input/main.tf
+++ b/test/fixture/terraform_15_1.0/google_container_cluster/input/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_15_1.0/google_labels_map/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0/google_labels_map/expected/main.terratag.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }
@@ -10,8 +11,6 @@ resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"
   force_destroy = true
-
-  bucket_policy_only = true
 
   website {
     main_page_suffix = "index.html"
@@ -27,6 +26,7 @@ resource "google_storage_bucket" "static-site" {
     "foo" = "bar"
   }), local.terratag_added_main)
 }
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }

--- a/test/fixture/terraform_15_1.0/google_labels_map/expected/main.tf.bak
+++ b/test/fixture/terraform_15_1.0/google_labels_map/expected/main.tf.bak
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }
@@ -10,8 +11,6 @@ resource "google_storage_bucket" "static-site" {
   name          = "image-store.com"
   location      = "EU"
   force_destroy = true
-
-  bucket_policy_only = true
 
   website {
     main_page_suffix = "index.html"

--- a/test/fixture/terraform_15_1.0/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_15_1.0/google_labels_map/input/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "4.1.0"
     }
   }
 }

--- a/test/fixture/terraform_15_1.0/google_labels_map/input/main.tf
+++ b/test/fixture/terraform_15_1.0/google_labels_map/input/main.tf
@@ -11,8 +11,6 @@ resource "google_storage_bucket" "static-site" {
   location      = "EU"
   force_destroy = true
 
-  bucket_policy_only = true
-
   website {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"


### PR DESCRIPTION
Tests has failed on validation since google tf plugin has been upgraded and we aren't fixing its version.

In this PR I've:
1. Fixed version to in all test fixtures (to the LTS supported version per TF version)
2. Removed the (unsupported anymore) `bucket_policy_only` attribute