### PR TITLE
Add support for arm64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,13 +1,16 @@
 builds:
   - binary: terratag
     goos:
-      - darwin
       - linux
+      - darwin
       - windows
     goarch:
       - amd64
       - arm64
-      - arm
+    ignore:
+      - goarch: arm64
+        goos: windows
+
     env:
       - CGO_ENABLED=0
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,8 @@
 builds:
   - binary: terratag
     goos:
-      - linux
       - darwin
+      - linux
       - windows
     goarch:
       - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
+      - arm
     env:
       - CGO_ENABLED=0
 


### PR DESCRIPTION
This configures goreleaser to publish arm64 binaries for Linux and macOS, mainly with the goal of adding M1 support. I have ignored Windows arm64 due to [this error](https://github.com/golang/go/issues/46761) popping up during the compilation. 