### PR TITLE
Fix: running more than once with -rename=false will corrupt hcl file

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -2,6 +2,9 @@ package convert
 
 import (
 	"encoding/json"
+	"log"
+	"strings"
+
 	"github.com/env0/terratag/errors"
 	"github.com/env0/terratag/tag_keys"
 	"github.com/env0/terratag/utils"
@@ -9,8 +12,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/thoas/go-funk"
 	"github.com/zclconf/go-cty/cty"
-	"log"
-	"strings"
 )
 
 func GetExistingTagsExpression(tokens hclwrite.Tokens, tfVersion Version) string {
@@ -114,11 +115,27 @@ func stringifyExpression(tokens hclwrite.Tokens) string {
 }
 
 func AppendLocalsBlock(file *hclwrite.File, filename string, terratag TerratagLocal) {
+	key := tag_keys.GetTerratagAddedKey(filename)
+
+	// If there's an existings terratag locals, remove it.
+	// A merged one will be added instead.
+	blocks := file.Body().Blocks()
+	for _, block := range blocks {
+		if block.Type() != "locals" {
+			continue
+		}
+		if block.Body().GetAttribute(key) == nil {
+			continue
+		}
+		file.Body().RemoveBlock(block)
+		break
+	}
+
 	file.Body().AppendNewline()
 	locals := file.Body().AppendNewBlock("locals", nil)
 	file.Body().AppendNewline()
 
-	locals.Body().SetAttributeValue(tag_keys.GetTerratagAddedKey(filename), cty.StringVal(terratag.Added))
+	locals.Body().SetAttributeValue(key, cty.StringVal(terratag.Added))
 }
 
 func AppendTagBlocks(resource *hclwrite.Block, tags string) {

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -117,8 +117,7 @@ func stringifyExpression(tokens hclwrite.Tokens) string {
 func AppendLocalsBlock(file *hclwrite.File, filename string, terratag TerratagLocal) {
 	key := tag_keys.GetTerratagAddedKey(filename)
 
-	// If there's an existings terratag locals, remove it.
-	// A merged one will be added instead.
+	// If there's an existings terratag locals replace it with the merged locals.
 	blocks := file.Body().Blocks()
 	for _, block := range blocks {
 		if block.Type() != "locals" {
@@ -127,8 +126,11 @@ func AppendLocalsBlock(file *hclwrite.File, filename string, terratag TerratagLo
 		if block.Body().GetAttribute(key) == nil {
 			continue
 		}
-		file.Body().RemoveBlock(block)
-		break
+
+		block.Body().RemoveAttribute(key)
+		block.Body().SetAttributeValue(key, cty.StringVal(terratag.Added))
+
+		return
 	}
 
 	file.Body().AppendNewline()

--- a/convert/locals.go
+++ b/convert/locals.go
@@ -1,0 +1,62 @@
+package convert
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+var localsRegex = regexp.MustCompile(`"([^"]*)"[ ]*=[ ]*"([^"]*)"`)
+
+type Locals map[string]string
+
+func decodeLocals(locals Locals, s string) error {
+	for k := range locals {
+		delete(locals, k)
+	}
+
+	matches := localsRegex.FindAllStringSubmatch(s, -1)
+	if matches == nil {
+		return errors.New("no matches found when decoding locals")
+	}
+
+	for _, match := range matches {
+		locals[match[1]] = match[2]
+	}
+
+	return nil
+}
+
+func encodeLocals(locals Locals) string {
+	ret := "{"
+	for key, value := range locals {
+		ret += fmt.Sprintf("\"%s\" = \"%s\", ", key, value)
+	}
+
+	ret = strings.TrimSuffix(ret, ", ")
+	ret += "}"
+	return ret
+}
+
+func MergeLocals(attribute *hclwrite.Attribute, added string) (string, error) {
+	localsAttribute := Locals{}
+	tokens := hclwrite.Tokens{}
+	existingLocalsExpression := stringifyExpression(attribute.BuildTokens(tokens))
+	if err := decodeLocals(localsAttribute, existingLocalsExpression); err != nil {
+		return "", err
+	}
+
+	localsAdded := Locals{}
+	if err := decodeLocals(localsAdded, added); err != nil {
+		return "", err
+	}
+
+	for key, value := range localsAdded {
+		localsAttribute[key] = value
+	}
+
+	return encodeLocals(localsAttribute), nil
+}

--- a/main.go
+++ b/main.go
@@ -130,11 +130,11 @@ func tagFileResources(path string, dir string, filter string, tags string, tfVer
 			key := tag_keys.GetTerratagAddedKey(filename)
 			for attributeKey, attribute := range attributes {
 				if attributeKey == key {
-					mergedLocals, err := convert.MergeLocals(attribute, terratag.Added)
+					mergedAdded, err := convert.MergeTerratagLocals(attribute, terratag.Added)
 					if err != nil {
 						errors.PanicOnError(err, nil)
 					}
-					terratag.Added = mergedLocals
+					terratag.Added = mergedAdded
 
 					break
 				}

--- a/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/expected/main.terratag.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(tomap({
+    "Name" = "My bucket"
+  }), local.terratag_added_main)
+}
+
+resource "aws_s3_bucket" "c" {
+  bucket = "my-tf-test-bucket2"
+  acl    = "private"
+  tags   = local.terratag_added_main
+}
+
+locals {
+  localTagKey  = "localTagKey"
+  localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
+}
+
+locals {
+  terratag_added_main = {"some_tag" = "value", "env0_environment_id" = "40907eff-cf7c-419a-8694-e1c6bf1d1168", "env0_project_id" = "43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+}

--- a/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/expected/main.terratag.tf
+++ b/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/expected/main.terratag.tf
@@ -7,9 +7,9 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge(tomap({
+  tags = merge(merge(tomap({
     "Name" = "My bucket"
-  }), local.terratag_added_main)
+  }), local.terratag_added_main), local.terratag_added_main)
 }
 
 resource "aws_s3_bucket" "c" {
@@ -27,5 +27,5 @@ locals {
 }
 
 locals {
-  terratag_added_main = {"some_tag" = "value", "env0_environment_id" = "40907eff-cf7c-419a-8694-e1c6bf1d1168", "env0_project_id" = "43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
+  terratag_added_main = {"env0_environment_id" = "40907eff-cf7c-419a-8694-e1c6bf1d1168", "env0_project_id" = "43fd4ff1-8d37-4d9d-ac97-295bd850bf94", "some_tag" = "value"}
 }

--- a/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/expected/main.tf.bak
+++ b/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/expected/main.tf.bak
@@ -1,0 +1,30 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(tomap({
+    "Name" = "My bucket"
+  }), local.terratag_added_main)
+}
+
+resource "aws_s3_bucket" "c" {
+  bucket = "my-tf-test-bucket2"
+  acl    = "private"
+}
+
+locals {
+  localTagKey  = "localTagKey"
+  localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
+}
+
+locals {
+  terratag_added_main = {"some_tag"="value"}
+}

--- a/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/input/main.tf
+++ b/test/fixture/terraform_15_1.0/git_issue_88__corrupt_hcl_file/input/main.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = merge(tomap({
+    "Name" = "My bucket"
+  }), local.terratag_added_main)
+}
+
+resource "aws_s3_bucket" "c" {
+  bucket = "my-tf-test-bucket2"
+  acl    = "private"
+}
+
+locals {
+  localTagKey  = "localTagKey"
+  localTagKey2 = "localTagKey2"
+  localMap = {
+    key = "value"
+  }
+}
+
+locals {
+  terratag_added_main = {"some_tag"="value"}
+}


### PR DESCRIPTION
fixes #88.
Avoids corruption and duplication when running a formatted file.