### PR TITLE
Fix: passing a non-JSON string to terratag should not panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/env0/terratag/cli"
 	"github.com/env0/terratag/convert"
 	"github.com/env0/terratag/errors"
-	. "github.com/env0/terratag/errors"
 	"github.com/env0/terratag/file"
 	. "github.com/env0/terratag/providers"
 	"github.com/env0/terratag/tag_keys"
@@ -162,7 +161,10 @@ func tagFileResources(path string, dir string, filter string, tags string, tfVer
 func jsonToHclMap(tags string) string {
 	var tagsMap map[string]string
 	err := json.Unmarshal([]byte(tags), &tagsMap)
-	PanicOnError(err, nil)
+	if err != nil {
+		log.Printf("[ERROR] Invalid input tags! must be a valid JSON.\nInput: %s\nError: %s\n", tags, err.Error())
+		os.Exit(1)
+	}
 
 	keys := utils.SortObjectKeys(tagsMap)
 


### PR DESCRIPTION
Print a log message and exit(1) instead.

```
➜  tf git:(fix-invalid-json-not-panic-#120) ✗ ../terratag -tags='fsdfsdfsdfds' -rename=false -dir=.
2022/04/21 07:10:39 [INFO] Processing file main.tf
2022/04/21 07:10:39 [ERROR] Invalid input tags! must be a valid JSON.
Input: fsdfsdfsdfds
Error: invalid character 's' in literal false (expecting 'a')
➜  tf git:(fix-invalid-json-not-panic-#120) ✗ echo $?
1

```