### PR TITLE
Chore: fail fast on npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
   npmbuild:
+    needs: goreleaser
     name: Build for Alpine and publish node artifact
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Make sure that we don't npm publish unless go release has finished succesfully