### PR TITLE
Fix: race conditions during run

### DIFF
--- a/terratag_test.go
+++ b/terratag_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/bmatcuk/doublestar"
@@ -28,6 +29,7 @@ var args = []string{
 }
 var testsDir = "test/tests"
 var fixtureDir = "test/fixture"
+var osArgsLock sync.Mutex
 
 type TestCase struct {
 	suite    string
@@ -233,17 +235,19 @@ func run_terratag(entryDir string, filter string) (err interface{}) {
 			err = innerErr
 		}
 	}()
+	osArgsLock.Lock()
 	if filter == "" {
 		os.Args = append(args, "-dir="+entryDir)
 	} else {
 		os.Args = append(args, "-dir="+entryDir, "-filter="+filter)
 	}
 	args, isMissingArg := cli.InitArgs()
+	os.Args = cleanArgs
+	osArgsLock.Unlock()
 	if isMissingArg {
 		return errors.New("Missing arg")
 	}
 	Terratag(args)
-	os.Args = cleanArgs
 
 	return nil
 }


### PR DESCRIPTION
Added mutex where required.

The following still occurs but seems to be a minor bug in HCL
https://github.com/hashicorp/hcl/issues/533

```
Write at 0x00000279f420 by goroutine 126:
  github.com/hashicorp/hcl/v2/hclwrite.formatSpaces()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/format.go:127 +0x29d
  github.com/hashicorp/hcl/v2/hclwrite.format()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/format.go:36 +0x6c
  github.com/hashicorp/hcl/v2/hclwrite.TokensForValue()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/generate.go:25 +0x8a
  github.com/hashicorp/hcl/v2/hclwrite.NewExpressionLiteral()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/ast_expression.go:61 +0x97
  github.com/hashicorp/hcl/v2/hclwrite.(*Body).SetAttributeValue()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/ast_body.go:167 +0x23d
  github.com/env0/terratag/internal/convert.AppendTagBlocks()
      /Users/theber/code/terratag/internal/convert/convert.go:153 +0x93a
  github.com/env0/terratag/internal/tagging.tagAutoscalingGroup()
      /Users/theber/code/terratag/internal/tagging/aws.go:9 +0x38
  github.com/env0/terratag/internal/tagging.TagResource()
      /Users/theber/code/terratag/internal/tagging/tagging.go:67 +0x157
  github.com/env0/terratag.tagFileResources()
      /Users/theber/code/terratag/terratag.go:147 +0xba4
  github.com/env0/terratag.tagDirectoryResources.func1()
      /Users/theber/code/terratag/terratag.go:86 +0x1e4
  github.com/env0/terratag.tagDirectoryResources.func2()
      /Users/theber/code/terratag/terratag.go:93 +0x58

Previous write at 0x00000279f420 by goroutine 100:
  github.com/hashicorp/hcl/v2/hclwrite.formatSpaces()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/format.go:127 +0x29d
  github.com/hashicorp/hcl/v2/hclwrite.format()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/format.go:36 +0x6c
  github.com/hashicorp/hcl/v2/hclwrite.TokensForValue()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/generate.go:25 +0x8a
  github.com/hashicorp/hcl/v2/hclwrite.NewExpressionLiteral()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/ast_expression.go:61 +0x97
  github.com/hashicorp/hcl/v2/hclwrite.(*Body).SetAttributeValue()
      /Users/theber/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.8.0/hclwrite/ast_body.go:167 +0x23d
  github.com/env0/terratag/internal/convert.AppendLocalsBlock()
      /Users/theber/code/terratag/internal/convert/convert.go:141 +0xd9b
  github.com/env0/terratag.tagFileResources()
      /Users/theber/code/terratag/terratag.go:185 +0xdbd
  github.com/env0/terratag.tagDirectoryResources.func1()
      /Users/theber/code/terratag/terratag.go:86 +0x1e4
  github.com/env0/terratag.tagDirectoryResources.func2()
      /Users/theber/code/terratag/terratag.go:93 +0x58

```