### PR TITLE
Feat: support terragrunt - no cache folder usecase

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -76,6 +76,11 @@ func GetResourceType(resource hclwrite.Block) string {
 
 func getRootDir(iacType string) string {
 	if iacType == string(common.Terragrunt) {
+		if _, err := os.Stat("/.terragrunt-cache"); err != nil {
+			if os.IsNotExist(err) {
+				return "/"
+			}
+		}
 		return "/.terragrunt-cache"
 	} else {
 		return "/.terraform"


### PR DESCRIPTION
Implemented as suggested by Elad:
```The solution for this, IMO, is to first look for the .terragrunt-cache folder and only if it exists look for the *.tf there, otherwise just look in the cwd```