### PR TITLE
Fix: aws_autoscaling_group that is using tags can't work with terratag

### DIFF
--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -1,13 +1,42 @@
 package tagging
 
-import "github.com/env0/terratag/internal/convert"
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/env0/terratag/internal/convert"
+	"github.com/env0/terratag/internal/tag_keys"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
 
 func tagAutoscalingGroup(args TagBlockArgs) (*Result, error) {
-	// for now, we count on it that if there's a single "tag" in the schema (unlike "tags" block),
-	// then no "tags" interpolation is used, but rather multiple instances of a "tag" block
 	// https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html
-	if err := convert.AppendTagBlocks(args.Block, args.Tags); err != nil {
+
+	var tagsMap map[string]string
+	if err := json.Unmarshal([]byte(args.Tags), &tagsMap); err != nil {
 		return nil, err
+	}
+
+	tagsAttr := args.Block.Body().GetAttribute("tags")
+	if tagsAttr != nil {
+		// "tags" interpolation is used
+		tokens := tagsAttr.Expr().BuildTokens(hclwrite.Tokens{})
+		expression := strings.TrimSpace(string(tokens.Bytes()))
+		// may be wrapped with ${ } in TF11
+		expression = strings.TrimPrefix(expression, "${")
+		expression = strings.TrimSuffix(expression, "${")
+
+		key := "local." + tag_keys.GetTerratagAddedKey(args.Filename)
+		newTagsValue := "flatten([" + key + "," + expression + "])"
+
+		newTags := ParseHclValueStringToTokens(newTagsValue)
+
+		args.Block.Body().SetAttributeRaw("tags", newTags)
+	} else {
+		// no "tags" interpolation is used, but rather multiple instances of a "tag" block
+		if err := convert.AppendTagBlocks(args.Block, args.Tags); err != nil {
+			return nil, err
+		}
 	}
 
 	return &Result{}, nil

--- a/test/fixture/terraform_11/config.yaml
+++ b/test/fixture/terraform_11/config.yaml
@@ -1,7 +1,4 @@
 suites:
-  - aws_autoscaling_group
-  - aws_submodule
-  - aws_tags_block
   - aws_tags_map_11
   - aws_tags_merge
   - azurerm_kubernetes_cluster_11

--- a/test/fixture/terraform_12/config.yaml
+++ b/test/fixture/terraform_12/config.yaml
@@ -5,12 +5,12 @@ suites:
   - aws_tags_map
   - azurerm_kubernetes_cluster
   - azurerm_tags_map
-  - azurestack_tags_map_11
+  - azurestack_tags_map
   - git_issue_17__tfschema_provider_not_from_prefix
   - git_issue_43__invalid_tf_files_in_subfolders
   - git_issue_56__line_ends_with_closing_paren
   - git_issue_66_aws_aliased_provider
   - git_issue_88__corrupt_hcl_file
   - google_beta_resource_skip
-  - google_container_cluster_11
-  - google_labels_map_11
+  - google_container_cluster
+  - google_labels_map

--- a/test/fixture/terraform_12/config.yaml
+++ b/test/fixture/terraform_12/config.yaml
@@ -5,12 +5,10 @@ suites:
   - aws_tags_map
   - azurerm_kubernetes_cluster
   - azurerm_tags_map
-  - azurestack_tags_map
   - git_issue_17__tfschema_provider_not_from_prefix
   - git_issue_43__invalid_tf_files_in_subfolders
   - git_issue_56__line_ends_with_closing_paren
   - git_issue_66_aws_aliased_provider
   - git_issue_88__corrupt_hcl_file
   - google_beta_resource_skip
-  - google_container_cluster
-  - google_labels_map
+  

--- a/test/tests/aws_autoscaling_group/expected/main.terratag.tf
+++ b/test/tests/aws_autoscaling_group/expected/main.terratag.tf
@@ -71,7 +71,7 @@ EOF
   }
 }
 
-resource "aws_autoscaling_group" "gar" {
+resource "aws_autoscaling_group" "bar_tags" {
   name                      = "foobar3-terraform-test"
   max_size                  = 5
   min_size                  = 2
@@ -100,7 +100,7 @@ EOF
     delete = "15m"
   }
 
-  tags = flatten([local.terratag_added_main, [
+  tags = flatten([[
     {
       key   = "a"
       value = "b"

--- a/test/tests/aws_autoscaling_group/expected/main.terratag.tf
+++ b/test/tests/aws_autoscaling_group/expected/main.terratag.tf
@@ -100,7 +100,7 @@ EOF
     delete = "15m"
   }
 
-  tags = flatten([[
+  tags = flatten([local.terratag_added_main, [
     {
       key   = "a"
       value = "b"
@@ -115,3 +115,4 @@ EOF
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }
+

--- a/test/tests/aws_autoscaling_group/expected/main.terratag.tf
+++ b/test/tests/aws_autoscaling_group/expected/main.terratag.tf
@@ -70,7 +70,48 @@ EOF
     propagate_at_launch = true
   }
 }
+
+resource "aws_autoscaling_group" "gar" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  initial_lifecycle_hook {
+    name                 = "foobar"
+    default_result       = "CONTINUE"
+    heartbeat_timeout    = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+
+    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
+    role_arn                = "arn:aws:iam::123456789012:role/S3Access"
+  }
+
+  timeouts {
+    delete = "15m"
+  }
+
+  tags = flatten([local.terratag_added_main, [
+    {
+      key   = "a"
+      value = "b"
+    },
+    {
+      key   = "c"
+      value = "d"
+    }
+  ]])
+}
+
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}
 }
-

--- a/test/tests/aws_autoscaling_group/expected/main.tf.bak
+++ b/test/tests/aws_autoscaling_group/expected/main.tf.bak
@@ -57,3 +57,44 @@ EOF
     propagate_at_launch = false
   }
 }
+
+resource "aws_autoscaling_group" "bar_tags" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  initial_lifecycle_hook {
+    name                 = "foobar"
+    default_result       = "CONTINUE"
+    heartbeat_timeout    = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+
+    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
+    role_arn                = "arn:aws:iam::123456789012:role/S3Access"
+  }
+
+  timeouts {
+    delete = "15m"
+  }
+
+  tags = [
+    {
+      key   = "a"
+      value = "b"
+    },
+    {
+      key   = "c"
+      value = "d"
+    }
+  ]
+}

--- a/test/tests/aws_autoscaling_group/input/main.tf
+++ b/test/tests/aws_autoscaling_group/input/main.tf
@@ -57,3 +57,44 @@ EOF
     propagate_at_launch = false
   }
 }
+
+resource "aws_autoscaling_group" "bar_tags" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  initial_lifecycle_hook {
+    name                 = "foobar"
+    default_result       = "CONTINUE"
+    heartbeat_timeout    = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+
+    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
+    role_arn                = "arn:aws:iam::123456789012:role/S3Access"
+  }
+
+  timeouts {
+    delete = "15m"
+  }
+
+  tags = [
+    {
+      key   = "a"
+      value = "b"
+    },
+    {
+      key   = "c"
+      value = "d"
+    }
+  ]
+}

--- a/test/tests/aws_azure/expected/main.terratag.tf
+++ b/test/tests/aws_azure/expected/main.terratag.tf
@@ -21,9 +21,9 @@ provider "aws" {
 resource "azurerm_resource_group" "should_have_tags" {
   name     = "example-resources"
   location = "West Europe"
-  tags = merge(tomap({
+  tags = merge({
     "oh" = "my"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 
 resource "azurerm_virtual_network" "should_not_have_tags" {
@@ -37,9 +37,9 @@ resource "aws_s3_bucket" "should_have_tags" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge(tomap({
+  tags = merge({
     "Name" = "My bucket"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 
 locals {

--- a/test/tests/aws_submodule/expected/child/child.terratag.tf
+++ b/test/tests/aws_submodule/expected/child/child.terratag.tf
@@ -2,10 +2,10 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge(tomap({
+  tags = merge({
     "Name"        = "My bucket"
     "Environment" = "Dev"
-  }), local.terratag_added_child)
+  }, local.terratag_added_child)
 }
 locals {
   terratag_added_child = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/tests/aws_tags_block/expected/main.terratag.tf
+++ b/test/tests/aws_tags_block/expected/main.terratag.tf
@@ -15,9 +15,9 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge(tomap({
+  tags = merge({
     "Name" = "My bucket"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/tests/aws_tags_map/expected/main.terratag.tf
+++ b/test/tests/aws_tags_map/expected/main.terratag.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge(tomap({
+  tags = merge({
     "Name"                       = "My bucket"
     "Unquoted1"                  = "I wanna be quoted"
     "AnotherName"                = "Yo"
@@ -27,7 +27,7 @@ resource "aws_s3_bucket" "b" {
     "Yo-${local.localTagKey}"    = "Test variable inside key"
     "Test variable as value"     = "${local.localTagKey}"
     "Test variable inside value" = "Yo-${local.localTagKey}"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 
 resource "aws_s3_bucket" "a" {

--- a/test/tests/azurerm_kubernetes_cluster/expected/main.terratag.tf
+++ b/test/tests/azurerm_kubernetes_cluster/expected/main.terratag.tf
@@ -56,9 +56,9 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     name       = "pool"
     node_count = 2
     vm_size    = "Standard_D2_v2"
-    tags = merge(tomap({
+    tags = merge({
       "existing" = "tag"
-    }), local.terratag_added_main)
+    }, local.terratag_added_main)
   }
 
   network_profile {
@@ -66,9 +66,9 @@ resource "azurerm_kubernetes_cluster" "existing_tags_cluster" {
     network_plugin    = "kubenet"
   }
 
-  tags = merge(tomap({
+  tags = merge({
     "existing" = "tag"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 
 locals {

--- a/test/tests/azurerm_tags_map/expected/main.terratag.tf
+++ b/test/tests/azurerm_tags_map/expected/main.terratag.tf
@@ -13,9 +13,9 @@ provider "azurerm" {
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
-  tags = merge(tomap({
+  tags = merge({
     "oh" = "my"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/test/tests/azurestack_tags_map/expected/main.terratag.tf
+++ b/test/tests/azurestack_tags_map/expected/main.terratag.tf
@@ -6,6 +6,10 @@ terraform {
   }
 }
 
+provider "azurestack" {
+  features {}
+}
+
 resource "azurestack_resource_group" "test" {
   name     = "production"
   location = "West US"
@@ -26,9 +30,9 @@ resource "azurestack_virtual_network" "test2" {
   address_space       = ["10.0.0.0/16"]
   location            = azurestack_resource_group.test.location
   resource_group_name = azurestack_resource_group.test.name
-  tags = merge(tomap({
+  tags = merge({
     "yo" = "ho"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/tests/azurestack_tags_map/expected/main.tf.bak
+++ b/test/tests/azurestack_tags_map/expected/main.tf.bak
@@ -6,6 +6,10 @@ terraform {
   }
 }
 
+provider "azurestack" {
+  features {}
+}
+
 resource "azurestack_resource_group" "test" {
   name     = "production"
   location = "West US"

--- a/test/tests/git_issue_43__invalid_tf_files_in_subfolders/expected/main.terratag.tf
+++ b/test/tests/git_issue_43__invalid_tf_files_in_subfolders/expected/main.terratag.tf
@@ -15,9 +15,9 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags = merge(tomap({
+  tags = merge({
     "Name" = "My bucket"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 locals {
   terratag_added_main = {"env0_environment_id"="40907eff-cf7c-419a-8694-e1c6bf1d1168","env0_project_id"="43fd4ff1-8d37-4d9d-ac97-295bd850bf94"}

--- a/test/tests/google_container_cluster/expected/main.terratag.tf
+++ b/test/tests/google_container_cluster/expected/main.terratag.tf
@@ -35,9 +35,9 @@ resource "google_container_cluster" "existing-labels-cluster" {
   name     = "cluster2"
   location = "us-central1"
 
-  resource_labels = merge(tomap({
+  resource_labels = merge({
     "foo" = "bar"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 
   node_config {
     machine_type = "n1-standard-1"

--- a/test/tests/google_labels_map/expected/main.terratag.tf
+++ b/test/tests/google_labels_map/expected/main.terratag.tf
@@ -22,9 +22,9 @@ resource "google_storage_bucket" "static-site" {
     response_header = ["*"]
     max_age_seconds = 3600
   }
-  labels = merge(tomap({
+  labels = merge({
     "foo" = "bar"
-  }), local.terratag_added_main)
+  }, local.terratag_added_main)
 }
 
 locals {


### PR DESCRIPTION
Added support for the "tags" usecase.
Added the use-case to the integration tests.
Fixed (major) issues with the integration tests.

Fixes #101 