### PR TITLE
Fix: terratag --version command is broken

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build project
         run: |
           mkdir out
-          CGO_ENABLED=0 go build -a -installsuffix cgo -o ./out/terratag/terratag ./cmd/terratag
+          CGO_ENABLED=0 go build -ldflags "-X main.version=${{github.ref_name}}" -a -installsuffix cgo -o ./out/terratag/terratag ./cmd/terratag
 
       # Setup .npmrc file to publish to GitHub Packages
       - name: Setup Node

--- a/cmd/terratag/main.go
+++ b/cmd/terratag/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/env0/terratag"
 	"github.com/env0/terratag/cli"
@@ -22,7 +23,11 @@ func main() {
 	}
 
 	if args.Version {
-		fmt.Printf("Terratag v%s\n", version)
+		var versionPrefix string
+		if !strings.HasPrefix(version, "v") {
+			versionPrefix = "v"
+		}
+		fmt.Printf("Terratag %s%s\n", versionPrefix, version)
 		return
 	}
 


### PR DESCRIPTION
pass the github tag while building the exectuable.