### PR TITLE
Feat: allow using terratag as a validation tool - add dryrun

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -49,7 +49,7 @@ func InitArgs() (Args, error) {
 	fs.BoolVar(&args.Rename, "rename", true, "Keep the original filename or replace it with <basename>.terratag.tf")
 	fs.StringVar(&args.Type, "type", string(common.Terraform), "The IAC type. Valid values: terraform or terragrunt")
 	fs.BoolVar(&args.Version, "version", false, "Prints the version")
-	fs.BoolVar(&args.DryRun, "dryrun", false, "Dry run and report of any files and resources without tags (does not modify the files). Non zero exit code is returned if such files and resources are found")
+	fs.BoolVar(&args.DryRun, "dryrun", false, "(BETA) Dry run and report of any files and resources without tags (does not modify the files). Non zero exit code is returned if such files and resources are found")
 
 	// Set cli args based on environment variables.
 	// The command line flags have precedence over environment variables.

--- a/cli/args.go
+++ b/cli/args.go
@@ -20,10 +20,11 @@ type Args struct {
 	Verbose             bool
 	Rename              bool
 	Version             bool
+	DryRun              bool
 }
 
 func validate(args Args) error {
-	if args.Tags == "" {
+	if args.Tags == "" && !args.DryRun {
 		return errors.New("missing tags")
 	}
 	if args.Type != string(common.Terraform) && args.Type != string(common.Terragrunt) {
@@ -48,9 +49,10 @@ func InitArgs() (Args, error) {
 	fs.BoolVar(&args.Rename, "rename", true, "Keep the original filename or replace it with <basename>.terratag.tf")
 	fs.StringVar(&args.Type, "type", string(common.Terraform), "The IAC type. Valid values: terraform or terragrunt")
 	fs.BoolVar(&args.Version, "version", false, "Prints the version")
+	fs.BoolVar(&args.DryRun, "dryrun", false, "Dry run and report of any files and resources without tags (does not modify the files). Non zero exit code is returned if such files and resources are found")
 
 	// Set cli args based on environment variables.
-	//The command line flags have precedence over environment variables.
+	// The command line flags have precedence over environment variables.
 	fs.VisitAll(func(f *flag.Flag) {
 		if f.Name == "version" {
 			return

--- a/cmd/terratag/main.go
+++ b/cmd/terratag/main.go
@@ -35,6 +35,7 @@ func main() {
 
 	if err := terratag.Terratag(args); err != nil {
 		log.Printf("[ERROR] execution failed due to an error\n%v", err)
+		os.Exit(1)
 	}
 }
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -24,6 +24,7 @@ type TaggingArgs struct {
 	Rename              bool
 	IACType             IACType
 	TFVersion           Version
+	DryRun              bool
 }
 
 type TerratagLocal struct {

--- a/internal/tagging/tagging.go
+++ b/internal/tagging/tagging.go
@@ -59,6 +59,19 @@ func HasResourceTagFn(resourceType string) bool {
 	return resourceTypeToFnMap[resourceType] != nil
 }
 
+func HasTags(args TagBlockArgs) (bool, error) {
+	// First we try to find tags as attribute
+	tagsAttribute := args.Block.Body().GetAttribute(args.TagId)
+
+	if tagsAttribute != nil {
+		return true, nil
+	}
+
+	// Otherwise, we try to get tags as block
+	tagsBlock := args.Block.Body().FirstMatchingBlock(args.TagId, nil)
+	return tagsBlock != nil, nil
+}
+
 func TagResource(args TagBlockArgs) (*Result, error) {
 	resourceType := terraform.GetResourceType(*args.Block)
 

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -212,7 +212,7 @@ func itShouldRunTerratag(entryDir string, filter string, skip string, g *GomegaW
 func itShouldRunTerratagDryRun(fail bool, entryDir string, filter string, skip string, g *GomegaWithT) {
 	err := run_terratag(entryDir, filter, skip, false, true)
 	if fail {
-		g.Expect(err).ToNot(BeNil(), "terratag dry run expected to fail by passed")
+		g.Expect(err).ToNot(BeNil(), "terratag dry run expected to fail but passed")
 	} else {
 		g.Expect(err).To(BeNil(), "terratag dry run failed")
 	}
@@ -339,7 +339,10 @@ func run_terratag(entryDir string, filter string, skip string, terragrunt bool, 
 	if err != nil {
 		return err
 	}
-	Terratag(args)
+
+	if err := Terratag(args); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -113,11 +113,10 @@ func testTerraform(t *testing.T, version string) {
 			t.Parallel() // marks each test case as capable of running in parallel with each other
 			g := NewWithT(t)
 			itShouldTerraformInit(tt.entryDir, g)
-			itShouldRunTerratagDryRun(true, tt.entryDir, "", "", g)
 			itShouldRunTerratag(tt.entryDir, "", "", g)
 			itShouldRunTerraformValidate(tt.entryDir, g)
 			itShouldGenerateExpectedTerratagFiles(tt.suiteDir, g)
-			itShouldRunTerratagDryRun(false, tt.entryDir, "", "", g)
+			itShouldRunTerratagDryRun(tt.entryDir, "", "", g)
 		})
 	}
 }
@@ -209,13 +208,9 @@ func itShouldRunTerratag(entryDir string, filter string, skip string, g *GomegaW
 	g.Expect(err).To(BeNil(), "terratag failed")
 }
 
-func itShouldRunTerratagDryRun(fail bool, entryDir string, filter string, skip string, g *GomegaWithT) {
+func itShouldRunTerratagDryRun(entryDir string, filter string, skip string, g *GomegaWithT) {
 	err := run_terratag(entryDir, filter, skip, false, true)
-	if fail {
-		g.Expect(err).ToNot(BeNil(), "terratag dry run expected to fail but passed")
-	} else {
-		g.Expect(err).To(BeNil(), "terratag dry run failed")
-	}
+	g.Expect(err).To(BeNil(), "terratag dry run failed")
 }
 
 func itShouldRunTerratagTerragruntMode(entryDir string, g *GomegaWithT) {

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -95,6 +95,7 @@ func TestTerragruntWithCache(t *testing.T) {
 	itShouldRunTerratagTerragruntMode(out, g)
 	itShouldRunTerragruntValidate(out, g)
 	itShouldGenerateExpectedTerragruntTerratagFiles(entryDir, g)
+	itShouldRunTerratagTerragruntModeDryRun(out, g)
 }
 
 func testTerraform(t *testing.T, version string) {
@@ -135,6 +136,7 @@ func testTerraformWithFilter(t *testing.T, version string, filter string, skip s
 			itShouldRunTerratag(tt.entryDir, filter, skip, g)
 			itShouldRunTerraformValidate(tt.entryDir, g)
 			itShouldGenerateExpectedTerratagFiles(tt.suiteDir, g)
+			itShouldRunTerratagDryRun(tt.entryDir, filter, skip, g)
 		})
 	}
 }
@@ -216,6 +218,11 @@ func itShouldRunTerratagDryRun(entryDir string, filter string, skip string, g *G
 func itShouldRunTerratagTerragruntMode(entryDir string, g *GomegaWithT) {
 	err := run_terratag(entryDir, "", "", true, false)
 	g.Expect(err).To(BeNil(), "terratag terragrunt mode failed")
+}
+
+func itShouldRunTerratagTerragruntModeDryRun(entryDir string, g *GomegaWithT) {
+	err := run_terratag(entryDir, "", "", true, true)
+	g.Expect(err).To(BeNil(), "terratag terragrunt mode dry run failed")
 }
 
 func itShouldTerraformInit(entryDir string, g *GomegaWithT) {


### PR DESCRIPTION
Added a new dryrun mode that checks if all resources are tagged.
If a resource isn't tagged, it returns 1 exit code.

resolves #178 