### PR TITLE
Fix: AWS EC2 volume tag errors

### DIFF
--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -20,23 +20,18 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 
 	useVolumeTags := true
 
-	rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil)
-	ebsBlockDevice := args.Block.Body().FirstMatchingBlock("ebs_block_device", nil)
-
 	// Use volume tags if tags aren't used in both 'root_block_device' and 'ebs_block_device'.
 	// See tag guide for additional details: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#tag-guide
 
-	if rootBlockDevice != nil || ebsBlockDevice != nil {
-		for _, block := range args.Block.Body().Blocks() {
-			if block.Type() != "root_block_device" && block.Type() != "ebs_block_device" {
-				continue
-			}
+	for _, block := range args.Block.Body().Blocks() {
+		if block.Type() != "root_block_device" && block.Type() != "ebs_block_device" {
+			continue
+		}
 
-			if block.Body().GetAttribute("tags") != nil {
-				// found at least one device block with 'tags' attribute. Cannot use 'volume_tags'.
-				useVolumeTags = false
-				break
-			}
+		if block.Body().GetAttribute("tags") != nil {
+			// found at least one device block with 'tags' attribute. Cannot use 'volume_tags'.
+			useVolumeTags = false
+			break
 		}
 	}
 

--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -46,7 +46,6 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 		swappedTagsStrings = append(swappedTagsStrings, volumeTagBlock)
 	} else {
 		// tag 'root_block_device' block (if it exists).
-
 		if rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil); rootBlockDevice != nil {
 			origArgsBlock := args.Block
 			args.Block = rootBlockDevice

--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -18,25 +18,14 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 	}
 	swappedTagsStrings = append(swappedTagsStrings, tagBlock)
 
-	useVolumeTags := true
-
-	// Use volume tags if tags aren't used in both 'root_block_device' and 'ebs_block_device'.
+	// Tag 'volume_tags' if it exists.
+	// Else:
+	//  1. create 'root_block_device' block (if not exist) and add tags to it.
+	//  2. add tags to any existing 'ebs_block_device' block.
 	// See tag guide for additional details: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#tag-guide
 
-	for _, block := range args.Block.Body().Blocks() {
-		if block.Type() != "root_block_device" && block.Type() != "ebs_block_device" {
-			continue
-		}
-
-		if block.Body().GetAttribute("tags") != nil {
-			// found at least one device block with 'tags' attribute. Cannot use 'volume_tags'.
-			useVolumeTags = false
-			break
-		}
-	}
-
-	if useVolumeTags {
-		// tag 'volume_tags'.
+	if args.Block.Body().GetAttribute("volume_tags") != nil {
+		// Add tags to 'volume_tags' attribute.
 		volumeTagBlockArgs := args
 		volumeTagBlockArgs.TagId = "volume_tags"
 		volumeTagBlock, err := TagBlock(volumeTagBlockArgs)
@@ -45,30 +34,36 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 		}
 		swappedTagsStrings = append(swappedTagsStrings, volumeTagBlock)
 	} else {
-		// tag 'root_block_device' block (if it exists).
-		if rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil); rootBlockDevice != nil {
-			origArgsBlock := args.Block
-			args.Block = rootBlockDevice
-			tagBlock, err := TagBlock(args)
-			if err != nil {
-				return nil, err
-			}
-			swappedTagsStrings = append(swappedTagsStrings, tagBlock)
-			args.Block = origArgsBlock
+		rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil)
+		if rootBlockDevice == nil {
+			// Create 'root_block_device' block.
+			rootBlockDevice = args.Block.Body().AppendNewBlock("root_block_device", nil)
 		}
 
-		// tag 'ebs_block_device' blocks (if any exist).
+		// Add tags to 'root_block_device' block.
+		origArgsBlock := args.Block
+		args.Block = rootBlockDevice
+		tagBlock, err := TagBlock(args)
+		if err != nil {
+			return nil, err
+		}
+		swappedTagsStrings = append(swappedTagsStrings, tagBlock)
+		args.Block = origArgsBlock
+
+		// Add tags to any 'ebs_block_device' blocks (if any exist).
 		for _, block := range args.Block.Body().Blocks() {
 			if block.Type() != "ebs_block_device" {
 				continue
 			}
 
+			origArgsBlock := args.Block
 			args.Block = block
 			tagBlock, err := TagBlock(args)
 			if err != nil {
 				return nil, err
 			}
 			swappedTagsStrings = append(swappedTagsStrings, tagBlock)
+			args.Block = origArgsBlock
 		}
 	}
 

--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -46,7 +46,8 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 		swappedTagsStrings = append(swappedTagsStrings, volumeTagBlock)
 	} else {
 		// tag 'root_block_device' block (if it exists).
-		if rootBlockDevice != nil {
+
+		if rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil); rootBlockDevice != nil {
 			origArgsBlock := args.Block
 			args.Block = rootBlockDevice
 			tagBlock, err := TagBlock(args)

--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -18,13 +18,24 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 	}
 	swappedTagsStrings = append(swappedTagsStrings, tagBlock)
 
-	volumeTagBlockArgs := args
-	volumeTagBlockArgs.TagId = "volume_tags"
-	volumeTagBlock, err := TagBlock(volumeTagBlockArgs)
-	if err != nil {
-		return nil, err
+	rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil)
+
+	if rootBlockDevice == nil {
+		volumeTagBlockArgs := args
+		volumeTagBlockArgs.TagId = "volume_tags"
+		volumeTagBlock, err := TagBlock(volumeTagBlockArgs)
+		if err != nil {
+			return nil, err
+		}
+		swappedTagsStrings = append(swappedTagsStrings, volumeTagBlock)
+	} else {
+		args.Block = rootBlockDevice
+		tagBlock, err := TagBlock(args)
+		if err != nil {
+			return nil, err
+		}
+		swappedTagsStrings = append(swappedTagsStrings, tagBlock)
 	}
-	swappedTagsStrings = append(swappedTagsStrings, volumeTagBlock)
 
 	return &Result{SwappedTagsStrings: swappedTagsStrings}, nil
 }

--- a/test/tests/aws_instance_volume_tags/expected/main.tf
+++ b/test/tests/aws_instance_volume_tags/expected/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.0"
+      version = "~> 5.0"
     }
   }
 }
@@ -16,12 +16,25 @@ resource "aws_instance" "ubuntu" {
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
 
-
   tags = merge({
     "Name" = "terratag-test"
     "env"  = "test"
   }, local.terratag_added_main)
   volume_tags = local.terratag_added_main
+}
+
+resource "aws_instance" "ubuntu2" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+    tags = merge({
+      "a" = "b"
+    }, local.terratag_added_main)
+  }
+  tags = local.terratag_added_main
 }
 
 locals {

--- a/test/tests/aws_instance_volume_tags/expected/main.tf
+++ b/test/tests/aws_instance_volume_tags/expected/main.tf
@@ -11,19 +11,40 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "ubuntu" {
+resource "aws_instance" "instance_tags" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
 
   tags = merge({
-    "Name" = "terratag-test"
-    "env"  = "test"
+    "a" = "b"
   }, local.terratag_added_main)
   volume_tags = local.terratag_added_main
 }
 
-resource "aws_instance" "ubuntu2" {
+resource "aws_instance" "volume_tags" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+  }
+
+  volume_tags = merge({
+    "c" = "d"
+  }, local.terratag_added_main)
+
+  tags = merge({
+    "a" = "b"
+  }, local.terratag_added_main)
+}
+
+resource "aws_instance" "tags_in_root_block" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
@@ -32,6 +53,72 @@ resource "aws_instance" "ubuntu2" {
     volume_size = 8
     tags = merge({
       "a" = "b"
+    }, local.terratag_added_main)
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags        = local.terratag_added_main
+  }
+  tags = local.terratag_added_main
+}
+
+resource "aws_instance" "tags_in_ebs_block" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+    tags        = local.terratag_added_main
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = merge({
+      "a" = "b"
+    }, local.terratag_added_main)
+  }
+  tags = local.terratag_added_main
+}
+
+resource "aws_instance" "tags_in_both_blocks" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+    tags = merge({
+      "c" = "d"
+    }, local.terratag_added_main)
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = merge({
+      "a" = "b"
+    }, local.terratag_added_main)
+  }
+  tags = local.terratag_added_main
+}
+
+resource "aws_instance" "multiple_tags" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = merge({
+      "a" = "b"
+    }, local.terratag_added_main)
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = merge({
+      "c" = "d"
     }, local.terratag_added_main)
   }
   tags = local.terratag_added_main

--- a/test/tests/aws_instance_volume_tags/expected/main.tf
+++ b/test/tests/aws_instance_volume_tags/expected/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "instance_tags" {
+resource "aws_instance" "no_volume_tags" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
@@ -19,7 +19,9 @@ resource "aws_instance" "instance_tags" {
   tags = merge({
     "a" = "b"
   }, local.terratag_added_main)
-  volume_tags = local.terratag_added_main
+  root_block_device {
+    tags = local.terratag_added_main
+  }
 }
 
 resource "aws_instance" "volume_tags" {
@@ -44,37 +46,13 @@ resource "aws_instance" "volume_tags" {
   }, local.terratag_added_main)
 }
 
-resource "aws_instance" "tags_in_root_block" {
+resource "aws_instance" "root_block_device" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
 
   root_block_device {
     volume_size = 8
-    tags = merge({
-      "a" = "b"
-    }, local.terratag_added_main)
-  }
-
-  ebs_block_device {
-    device_name = "abcdefg"
-    tags        = local.terratag_added_main
-  }
-  tags = local.terratag_added_main
-}
-
-resource "aws_instance" "tags_in_ebs_block" {
-  ami               = "dasdasD"
-  instance_type     = "t3.micro"
-  availability_zone = "us-west-2"
-
-  root_block_device {
-    volume_size = 8
-    tags        = local.terratag_added_main
-  }
-
-  ebs_block_device {
-    device_name = "abcdefg"
     tags = merge({
       "a" = "b"
     }, local.terratag_added_main)
@@ -82,25 +60,14 @@ resource "aws_instance" "tags_in_ebs_block" {
   tags = local.terratag_added_main
 }
 
-resource "aws_instance" "tags_in_both_blocks" {
+resource "aws_instance" "root_block_device_does_not_exist" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
-
+  tags              = local.terratag_added_main
   root_block_device {
-    volume_size = 8
-    tags = merge({
-      "c" = "d"
-    }, local.terratag_added_main)
+    tags = local.terratag_added_main
   }
-
-  ebs_block_device {
-    device_name = "abcdefg"
-    tags = merge({
-      "a" = "b"
-    }, local.terratag_added_main)
-  }
-  tags = local.terratag_added_main
 }
 
 resource "aws_instance" "multiple_tags" {
@@ -122,6 +89,9 @@ resource "aws_instance" "multiple_tags" {
     }, local.terratag_added_main)
   }
   tags = local.terratag_added_main
+  root_block_device {
+    tags = local.terratag_added_main
+  }
 }
 
 locals {

--- a/test/tests/aws_instance_volume_tags/input/main.tf
+++ b/test/tests/aws_instance_volume_tags/input/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.0"
+      version = "~> 5.0"
     }
   }
 }
@@ -16,9 +16,21 @@ resource "aws_instance" "ubuntu" {
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
 
-
   tags = {
     Name = "terratag-test"
     env  = "test"
+  }
+}
+
+resource "aws_instance" "ubuntu2" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+    tags = {
+      "a" = "b"
+    }
   }
 }

--- a/test/tests/aws_instance_volume_tags/input/main.tf
+++ b/test/tests/aws_instance_volume_tags/input/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "instance_tags" {
+resource "aws_instance" "no_volume_tags" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
@@ -43,58 +43,23 @@ resource "aws_instance" "volume_tags" {
   }
 }
 
-resource "aws_instance" "tags_in_root_block" {
+resource "aws_instance" "root_block_device" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
 
   root_block_device {
     volume_size = 8
-    tags = {
-      a = "b"
-    }
-  }
-
-  ebs_block_device {
-    device_name = "abcdefg"
-  }
-}
-
-resource "aws_instance" "tags_in_ebs_block" {
-  ami               = "dasdasD"
-  instance_type     = "t3.micro"
-  availability_zone = "us-west-2"
-
-  root_block_device {
-    volume_size = 8
-  }
-
-  ebs_block_device {
-    device_name = "abcdefg"
     tags = {
       a = "b"
     }
   }
 }
 
-resource "aws_instance" "tags_in_both_blocks" {
+resource "aws_instance" "root_block_device_does_not_exist" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
-
-  root_block_device {
-    volume_size = 8
-    tags = {
-      c = "d"
-    }
-  }
-
-  ebs_block_device {
-    device_name = "abcdefg"
-    tags = {
-      a = "b"
-    }
-  }
 }
 
 resource "aws_instance" "multiple_tags" {

--- a/test/tests/aws_instance_volume_tags/input/main.tf
+++ b/test/tests/aws_instance_volume_tags/input/main.tf
@@ -11,18 +11,39 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "ubuntu" {
+resource "aws_instance" "instance_tags" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
 
   tags = {
-    Name = "terratag-test"
-    env  = "test"
+    a = "b"
   }
 }
 
-resource "aws_instance" "ubuntu2" {
+resource "aws_instance" "volume_tags" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+  }
+
+  volume_tags = {
+    c = "d"
+  }
+
+  tags = {
+    a = "b"
+  }
+}
+
+resource "aws_instance" "tags_in_root_block" {
   ami               = "dasdasD"
   instance_type     = "t3.micro"
   availability_zone = "us-west-2"
@@ -30,7 +51,68 @@ resource "aws_instance" "ubuntu2" {
   root_block_device {
     volume_size = 8
     tags = {
-      "a" = "b"
+      a = "b"
+    }
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+  }
+}
+
+resource "aws_instance" "tags_in_ebs_block" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = {
+      a = "b"
+    }
+  }
+}
+
+resource "aws_instance" "tags_in_both_blocks" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  root_block_device {
+    volume_size = 8
+    tags = {
+      c = "d"
+    }
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = {
+      a = "b"
+    }
+  }
+}
+
+resource "aws_instance" "multiple_tags" {
+  ami               = "dasdasD"
+  instance_type     = "t3.micro"
+  availability_zone = "us-west-2"
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = {
+      a = "b"
+    }
+  }
+
+  ebs_block_device {
+    device_name = "abcdefg"
+    tags = {
+      c = "d"
     }
   }
 }


### PR DESCRIPTION
resolves #190 

Does not add tags to volume_tags if root_block_device block is used. (Per documentation they conflict).
I'm now also tagging root_block_device. I hope it makes sense.