### PR TITLE
Feat: add flag to not override existing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ locals {
 - `-type=<terraform or terragrunt>` - defaults to `terraform` (and `opentofu`). If `terragrunt` is used, tags the files under `.terragrunt-cache` folder. Note: if Terragrunt does not create a `.terragrunt-cache` folder, use the default or omit.
 - `-verbose` - Turn on verbose logging
 - `-default-to-terraform` By default uses OpenTofu (if installed), if set will use Terraform even when Opentofu is installed
+- `--keep-existing-tags` - When set, existing tags will be preserved when merging tags (by default, new tags override existing ones)
 
 Setting options via enviroment variables is also supported. CLI flags have a precedence over envrionment variables.
 
@@ -186,6 +187,7 @@ TERRATAG_VERBOSE
 TERRATAG_RENAME
 TERRATAG_TYPE
 TERRATAG_DEFAULT_TO_TERRAFORM
+TERRATAG_KEEP_EXISTING_TAGS
 ```
 
 ##### See more samples [here](https://github.com/env0/terratag/tree/master/test/fixture)

--- a/cli/args.go
+++ b/cli/args.go
@@ -21,6 +21,7 @@ type Args struct {
 	Rename              bool
 	Version             bool
 	DefaultToTerraform  bool
+	KeepExistingTags    bool
 }
 
 func validate(args Args) error {
@@ -52,6 +53,7 @@ func InitArgs() (Args, error) {
 	fs.StringVar(&args.Type, "type", string(common.Terraform), "The IAC type. Valid values: terraform or terragrunt")
 	fs.BoolVar(&args.Version, "version", false, "Prints the version")
 	fs.BoolVar(&args.DefaultToTerraform, "default-to-terraform", false, "By default uses OpenTofu (if installed), if set will use Terraform even when Opentofu is installed")
+	fs.BoolVar(&args.KeepExistingTags, "keep-existing-tags", false, "When set, existing tags will be preserved when merging tags (by default, new tags override existing ones)")
 
 	// Set cli args based on environment variables.
 	// The command line flags have precedence over environment variables.

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -24,6 +24,7 @@ type TaggingArgs struct {
 	Rename              bool
 	DefaultToTerraform  bool
 	IACType             IACType
+	KeepExistingTags    bool
 }
 
 type TerratagLocal struct {

--- a/internal/tagging/tagging.go
+++ b/internal/tagging/tagging.go
@@ -44,7 +44,15 @@ func TagBlock(args TagBlockArgs) (string, error) {
 	if hasExistingTags {
 		existingTagsKey := tag_keys.GetResourceExistingTagsKey(args.Filename, args.Block)
 		existingTagsExpression := convert.GetExistingTagsExpression(args.Terratag.Found[existingTagsKey])
-		newTagsValue = "merge( " + existingTagsExpression + ", " + terratagAddedKey + ")"
+
+		// Flip the order of arguments in merge based on KeepExistingTags flag
+		if args.KeepExistingTags {
+			// Existing tags take precedence (come second in merge arguments)
+			newTagsValue = "merge( " + terratagAddedKey + ", " + existingTagsExpression + ")"
+		} else {
+			// New tags take precedence (come second in merge arguments)
+			newTagsValue = "merge( " + existingTagsExpression + ", " + terratagAddedKey + ")"
+		}
 	}
 
 	newTagsValueTokens := ParseHclValueStringToTokens(newTagsValue)
@@ -77,11 +85,12 @@ var resourceTypeToFnMap = map[string]TagResourceFn{
 }
 
 type TagBlockArgs struct {
-	Filename string
-	Block    *hclwrite.Block
-	Tags     string
-	Terratag common.TerratagLocal
-	TagId    string
+	Filename         string
+	Block            *hclwrite.Block
+	Tags             string
+	Terratag         common.TerratagLocal
+	TagId            string
+	KeepExistingTags bool
 }
 
 type TagResourceFn func(args TagBlockArgs) (*Result, error)

--- a/internal/tagging/tagging_test.go
+++ b/internal/tagging/tagging_test.go
@@ -1,0 +1,71 @@
+package tagging
+
+import (
+	"testing"
+
+	"github.com/env0/terratag/internal/common"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagBlock_MergeOrder(t *testing.T) {
+	testCases := []struct {
+		name             string
+		keepExistingTags bool
+		expectedMerge    string // The complete expected merge expression
+	}{
+		{
+			name:             "Default behavior - new tags override existing",
+			keepExistingTags: false,
+			// When keepExistingTags=false, existing tags should come first in merge
+			expectedMerge: "merge( { \"Name\" = \"Original Name\", \"Environment\" = \"Dev\" }, local.terratag_added_main)",
+		},
+		{
+			name:             "Keep existing tags - existing tags override new",
+			keepExistingTags: true,
+			// When keepExistingTags=true, new tags should come first in merge
+			expectedMerge: "merge( local.terratag_added_main, { \"Name\" = \"Original Name\", \"Environment\" = \"Dev\" })",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a fresh block for each test case
+			f := hclwrite.NewEmptyFile()
+			rootBody := f.Body()
+			resourceBlock := rootBody.AppendNewBlock("resource", []string{"aws_s3_bucket", "test"})
+
+			// Add original tags
+			tagsTokens := ParseHclValueStringToTokens(`{ Name = "Original Name", Environment = "Dev" }`)
+			resourceBlock.Body().SetAttributeRaw("tags", tagsTokens)
+
+			// Set up terratag local with extracted existing tags
+			existingTagsToken := ParseHclValueStringToTokens(`{
+				"Name" = "Original Name",
+				"Environment" = "Dev"
+			}`)
+
+			terratag := common.TerratagLocal{
+				Found: map[string]hclwrite.Tokens{
+					"terratag_existing_tags_main_resource_aws_s3_bucket_test": existingTagsToken,
+				},
+				Added: `{"Name"="Terratag Name","Owner"="DevOps"}`,
+			}
+
+			args := TagBlockArgs{
+				Filename:         "main",
+				Block:            resourceBlock,
+				Tags:             `{"Name": "Terratag Name", "Owner": "DevOps"}`,
+				Terratag:         terratag,
+				TagId:            "tags",
+				KeepExistingTags: tc.keepExistingTags,
+			}
+
+			result, err := TagBlock(args)
+			assert.NoError(t, err)
+
+			// Compare the exact merge string
+			assert.Equal(t, tc.expectedMerge, result, "The merge expression doesn't match expected value")
+		})
+	}
+}

--- a/terratag.go
+++ b/terratag.go
@@ -60,6 +60,7 @@ func Terratag(args cli.Args) error {
 		Rename:              args.Rename,
 		IACType:             common.IACType(args.Type),
 		DefaultToTerraform:  args.DefaultToTerraform,
+		KeepExistingTags:    args.KeepExistingTags,
 	}
 
 	counters := tagDirectoryResources(taggingArgs)
@@ -176,11 +177,12 @@ func tagFileResources(path string, args *common.TaggingArgs) (*counters, error) 
 				perFileCounters.taggedResources += 1
 
 				result, err := tagging.TagResource(tagging.TagBlockArgs{
-					Filename: filename,
-					Block:    resource,
-					Tags:     args.Tags,
-					Terratag: terratag,
-					TagId:    providers.GetTagIdByResource(terraform.GetResourceType(*resource)),
+					Filename:         filename,
+					Block:            resource,
+					Tags:             args.Tags,
+					Terratag:         terratag,
+					TagId:            providers.GetTagIdByResource(terraform.GetResourceType(*resource)),
+					KeepExistingTags: args.KeepExistingTags,
 				})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
1. Added a new flag.
2. The flag flips the merge function order. The order of merge dictates whether it overrides existing tags or not.
3. Added a unit test.

resolves #217 