### PR TITLE
feat!: update terragrunt type to use run command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
   terragrunt-integration-tests:
     name: Terragrunt Integration Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terragrunt_version:
+          - "0.78.0"
+          - "0.95.1"
+          - "latest"
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -97,7 +104,7 @@ jobs:
       - name: Install Terragrunt
         uses: autero1/action-terragrunt@v3
         with:
-          terragrunt-version: 0.77.20
+          terragrunt-version: ${{ matrix.terragrunt_version }}
       - name: Print Terragrunt version
         run: |
           terragrunt --version

--- a/README.md
+++ b/README.md
@@ -202,6 +202,27 @@ TERRATAG_KEEP_EXISTING_TAGS
   - `azurestack`
   - `azapi`
 
+### Usage with Terragrunt
+
+Terratag supports Terragrunt v0.78.0 and above.
+> Note: Terragrunt hasn't released a stable 1.x version yet,
+  so compatibility with future releases isn't guaranteed.
+
+To use terratag with Terragrunt:
+
+- Use `-type=terragrunt` for a standard unit
+- Use `-type=terragrunt-run-all` for implicit stacks
+
+> Note: Explicit stacks are not explicitly supported.
+  If you are working with an explicit stack,
+  you may run terratag on each unit individually by using `-type=terragrunt` and `-dir=<unit_path>`.
+  If your generated stack is similar to an implicit stack,
+  you may use `-type=terragrunt-run-all` from the generated stack directory (`.terragrunt-stack` by default).
+  Remember to initialize the units in the stack by either running `terragrunt stack run init`,
+  or running `terragrunt init` in each unit beforehand.
+
+If issues arise with new Terragrunt versions, please open an issue.
+
 ## Develop
 
 Issues and Pull Requests are very welcome!

--- a/internal/tfschema/tfschema.go
+++ b/internal/tfschema/tfschema.go
@@ -65,13 +65,17 @@ func InitProviderSchemas(dir string, iacType common.IACType, defaultToTerraform 
 
 	log.Print("[INFO] Fetching provider schemas for directory: ", dir)
 
-	var cmd *exec.Cmd
-	if iacType == common.TerragruntRunAll {
-		log.Print("[INFO] Using terragrunt run-all mode")
-		cmd = exec.Command(name, "run-all", "providers", "schema", "-json")
-	} else {
-		cmd = exec.Command(name, "providers", "schema", "-json")
+	cmd := exec.Command(name)
+	if iacType == common.Terragrunt || iacType == common.TerragruntRunAll {
+		cmd.Args = append(cmd.Args, "run")
+		if iacType == common.TerragruntRunAll {
+			log.Print("[INFO] Using terragrunt run-all mode")
+			cmd.Args = append(cmd.Args, "--all")
+		}
+		cmd.Args = append(cmd.Args, "--")
 	}
+
+	cmd.Args = append(cmd.Args, "providers", "schema", "-json")
 	cmd.Dir = dir
 
 	out, err := cmd.Output()

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -243,8 +243,10 @@ func itShouldGenerateExpectedTerragruntTerratagFiles(entryDir string, g *GomegaW
 	expectedPattern := entryDir + "/expected/**/*.tf"
 	expectedTerratag, _ := doublestar.Glob(expectedPattern)
 
-	cachePattern := entryDir + "/out/**/.terragrunt-cache"
+	cachePattern := entryDir + "/out/**/unit*/.terragrunt-cache"
 	cacheDirs, _ := doublestar.Glob(cachePattern)
+
+	g.Expect(len(cacheDirs)).To(BeNumerically(">", 0))
 
 	for _, cacheDir := range cacheDirs {
 		hashmap := make(map[string]string)
@@ -458,9 +460,9 @@ func run_opentofu(entryDir string, cmd string) error {
 }
 
 func run_terragrunt(entryDir string, cmd string, runAll bool) error {
-	args := []string{}
+	args := []string{"run"}
 	if runAll {
-		args = append(args, "run-all")
+		args = append(args, "--all")
 	}
 	args = append(args, cmd)
 


### PR DESCRIPTION
Fix for #230

BREAKING CHANGE:

- Migrate terragrunt run types to use terragrunt's run command.
  - This is incompatible with version of terragrunt <  v0.78.0

Other changes:

- Add terragrunt usage notes to readme
- Update terragrunt integration tests to test several versions of terragrunt
- Update unit tests to only look for expected files in unit cache directories.