### PR TITLE
Enable terragrunt version v0.88.0^ and maintain legacy support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
   terragrunt-integration-tests:
     name: Terragrunt Integration Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terragrunt_version:
+          - "0.78.0"
+          - "0.95.1"
+          - "latest"
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -97,7 +104,7 @@ jobs:
       - name: Install Terragrunt
         uses: autero1/action-terragrunt@v3
         with:
-          terragrunt-version: 0.77.20
+          terragrunt-version: ${{ matrix.terragrunt_version }}
       - name: Print Terragrunt version
         run: |
           terragrunt --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         terragrunt_version:
+          - "0.77.20"
           - "0.78.0"
           - "0.95.1"
           - "latest"

--- a/README.md
+++ b/README.md
@@ -202,6 +202,27 @@ TERRATAG_KEEP_EXISTING_TAGS
   - `azurestack`
   - `azapi`
 
+### Usage with Terragrunt
+
+Terratag supports Terragrunt v0.78.0 and above.
+> Note: Terragrunt hasn't released a stable 1.x version yet,
+  so compatibility with future releases isn't guaranteed.
+
+To use terratag with Terragrunt:
+
+- Use `-type=terragrunt` for a standard unit
+- Use `-type=terragrunt-run-all` for implicit stacks
+
+> Note: Explicit stacks are not explicitly supported.
+  If you are working with an explicit stack,
+  you may run terratag on each unit individually by using `-type=terragrunt` and `-dir=<unit_path>`.
+  If your generated stack is similar to an implicit stack,
+  you may use `-type=terragrunt-run-all` from the generated stack directory (`.terragrunt-stack` by default).
+  Remember to initialize the units in the stack by either running `terragrunt stack run init`,
+  or running `terragrunt init` in each unit beforehand.
+
+If issues arise with new Terragrunt versions, please open an issue.
+
 ## Develop
 
 Issues and Pull Requests are very welcome!

--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ TERRATAG_KEEP_EXISTING_TAGS
 
 ### Usage with Terragrunt
 
-Terratag supports Terragrunt v0.78.0 and above.
 > Note: Terragrunt hasn't released a stable 1.x version yet,
   so compatibility with future releases isn't guaranteed.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.9
 require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/hashicorp/go-hclog v1.6.3
+	github.com/hashicorp/go-version v1.8.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
+github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/internal/terraform/version.go
+++ b/internal/terraform/version.go
@@ -1,0 +1,61 @@
+package terraform
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+
+	version "github.com/hashicorp/go-version"
+)
+
+var (
+	terragruntVersionOnce sync.Once
+	terragruntVersion     string
+	terragruntParsed      *version.Version
+	terragruntVersionErr  error
+)
+
+var terragruntVersionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+const TerragruntRunMinVersion = "0.78.0"
+
+func GetTerragruntVersion() (string, error) {
+	terragruntVersionOnce.Do(func() {
+		cmd := exec.Command("terragrunt", "--version")
+		out, err := cmd.Output()
+		if err != nil {
+			terragruntVersionErr = fmt.Errorf("failed to run 'terragrunt version': %w", err)
+			return
+		}
+
+		match := terragruntVersionRegex.FindStringSubmatch(string(out))
+		if len(match) < 1 {
+			terragruntVersionErr = fmt.Errorf("failed to parse terragrunt version from output: %s", strings.TrimSpace(string(out)))
+			return
+		}
+
+		terragruntVersion = match[0]
+		terragruntParsed, terragruntVersionErr = version.NewVersion(terragruntVersion)
+	})
+
+	return terragruntVersion, terragruntVersionErr
+}
+
+func IsTerragruntVersionAtLeast(minVersion string) (bool, error) {
+	if _, err := GetTerragruntVersion(); err != nil {
+		return false, err
+	}
+
+	minVer, err := version.NewVersion(minVersion)
+	if err != nil {
+		return false, fmt.Errorf("invalid min terragrunt version '%s': %w", minVersion, err)
+	}
+
+	return terragruntParsed.GreaterThanOrEqual(minVer), nil
+}
+
+func IsTerragruntRunSupported() (bool, error) {
+	return IsTerragruntVersionAtLeast(TerragruntRunMinVersion)
+}

--- a/internal/tfschema/tfschema.go
+++ b/internal/tfschema/tfschema.go
@@ -65,13 +65,17 @@ func InitProviderSchemas(dir string, iacType common.IACType, defaultToTerraform 
 
 	log.Print("[INFO] Fetching provider schemas for directory: ", dir)
 
-	var cmd *exec.Cmd
-	if iacType == common.TerragruntRunAll {
-		log.Print("[INFO] Using terragrunt run-all mode")
-		cmd = exec.Command(name, "run-all", "providers", "schema", "-json")
-	} else {
-		cmd = exec.Command(name, "providers", "schema", "-json")
+	cmd := exec.Command(name)
+	if iacType == common.Terragrunt || iacType == common.TerragruntRunAll {
+		cmd.Args = append(cmd.Args, "run")
+		if iacType == common.TerragruntRunAll {
+			log.Print("[INFO] Using terragrunt run-all mode")
+			cmd.Args = append(cmd.Args, "--all")
+		}
+		cmd.Args = append(cmd.Args, "--")
 	}
+
+	cmd.Args = append(cmd.Args, "providers", "schema", "-json")
 	cmd.Dir = dir
 
 	out, err := cmd.Output()

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bmatcuk/doublestar"
 	"github.com/env0/terratag/cli"
 	"github.com/env0/terratag/internal/common"
+	"github.com/env0/terratag/internal/terraform"
 	. "github.com/onsi/gomega"
 	"github.com/otiai10/copy"
 	"github.com/spf13/viper"
@@ -460,11 +461,25 @@ func run_opentofu(entryDir string, cmd string) error {
 }
 
 func run_terragrunt(entryDir string, cmd string, runAll bool) error {
-	args := []string{"run"}
-	if runAll {
-		args = append(args, "--all")
+	supportsRun, err := terraform.IsTerragruntRunSupported()
+	if err != nil {
+		return err
 	}
-	args = append(args, cmd)
+
+	args := []string{}
+	if supportsRun {
+		args = append(args, "run")
+		if runAll {
+			args = append(args, "--all")
+		}
+		args = append(args, cmd)
+	} else {
+		if runAll {
+			args = append(args, "run-all", cmd)
+		} else {
+			args = append(args, cmd)
+		}
+	}
 
 	return run("terragrunt", entryDir, args...)
 }

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -243,8 +243,10 @@ func itShouldGenerateExpectedTerragruntTerratagFiles(entryDir string, g *GomegaW
 	expectedPattern := entryDir + "/expected/**/*.tf"
 	expectedTerratag, _ := doublestar.Glob(expectedPattern)
 
-	cachePattern := entryDir + "/out/**/.terragrunt-cache"
+	cachePattern := entryDir + "/out/**/unit*/.terragrunt-cache"
 	cacheDirs, _ := doublestar.Glob(cachePattern)
+
+	g.Expect(len(cacheDirs)).To(BeNumerically(">", 0))
 
 	for _, cacheDir := range cacheDirs {
 		hashmap := make(map[string]string)
@@ -458,9 +460,9 @@ func run_opentofu(entryDir string, cmd string) error {
 }
 
 func run_terragrunt(entryDir string, cmd string, runAll bool) error {
-	args := []string{}
+	args := []string{"run"}
 	if runAll {
-		args = append(args, "run-all")
+		args = append(args, "--all")
 	}
 	args = append(args, cmd)
 


### PR DESCRIPTION
Alternative PR from #235 to fix #230

- Adds support for terragrunt v0.88.0 and up
- Maintains legacy support for versions of terragrunt < 0.78.0
- Updates docs for terragrunt support
- Update pipeline to test several versions of terragrunt
