### PR TITLE
Preserve nullable volume_tags for aws_instance

### DIFF
--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -19,7 +19,7 @@ func GetExistingTagsExpression(tokens hclwrite.Tokens) string {
 	return stringifyExpression(tokens)
 }
 
-func isHclMap(tokens hclwrite.Tokens) bool {
+func IsHclMap(tokens hclwrite.Tokens) bool {
 	maybeHclMap := strings.TrimSpace(string(tokens.Bytes()))
 
 	return strings.HasPrefix(maybeHclMap, "{") && strings.HasSuffix(maybeHclMap, "}")
@@ -154,7 +154,7 @@ func quoteAttributeKeys(tagsAttribute *hclwrite.Attribute) hclwrite.Tokens {
 	tags := tagsAttribute.Expr().BuildTokens(hclwrite.Tokens{})
 
 	// if attribute is a variable
-	if !(isHclMap(tags)) {
+	if !(IsHclMap(tags)) {
 		return tags
 	}
 

--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -26,11 +26,9 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 	// See tag guide for additional details: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#tag-guide
 
 	if volumeTagsAttribute := args.Block.Body().GetAttribute("volume_tags"); volumeTagsAttribute != nil {
-		originalVolumeTags := convert.GetExistingTagsExpression(
-			volumeTagsAttribute.Expr().BuildTokens(hclwrite.Tokens{}),
-		)
+		originalTokens := volumeTagsAttribute.Expr().BuildTokens(hclwrite.Tokens{})
 
-		// Add tags to 'volume_tags' attribute while preserving a runtime null value.
+		// Add tags to 'volume_tags' attribute.
 		volumeTagBlockArgs := args
 		volumeTagBlockArgs.TagId = "volume_tags"
 
@@ -39,13 +37,14 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 			return nil, err
 		}
 
-		guardedVolumeTagBlock :=
-			"(" + originalVolumeTags + ") == null ? null : " + volumeTagBlock
-		args.Block.Body().SetAttributeRaw(
-			"volume_tags",
-			ParseHclValueStringToTokens(guardedVolumeTagBlock),
-		)
-		swappedTagsStrings = append(swappedTagsStrings, guardedVolumeTagBlock)
+		// merge() drops null args, so a conditionally-null expression would become non-null and
+		// conflict with root_block_device.tags. Guard it; a literal map can never be null.
+		if !convert.IsHclMap(originalTokens) {
+			volumeTagBlock = "(" + convert.GetExistingTagsExpression(originalTokens) + ") == null ? null : " + volumeTagBlock
+			args.Block.Body().SetAttributeRaw("volume_tags", ParseHclValueStringToTokens(volumeTagBlock))
+		}
+
+		swappedTagsStrings = append(swappedTagsStrings, volumeTagBlock)
 	} else {
 		rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil)
 		if rootBlockDevice == nil {

--- a/internal/tagging/aws.go
+++ b/internal/tagging/aws.go
@@ -25,8 +25,12 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 	//  2. add tags to any existing 'ebs_block_device' block.
 	// See tag guide for additional details: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#tag-guide
 
-	if args.Block.Body().GetAttribute("volume_tags") != nil {
-		// Add tags to 'volume_tags' attribute.
+	if volumeTagsAttribute := args.Block.Body().GetAttribute("volume_tags"); volumeTagsAttribute != nil {
+		originalVolumeTags := convert.GetExistingTagsExpression(
+			volumeTagsAttribute.Expr().BuildTokens(hclwrite.Tokens{}),
+		)
+
+		// Add tags to 'volume_tags' attribute while preserving a runtime null value.
 		volumeTagBlockArgs := args
 		volumeTagBlockArgs.TagId = "volume_tags"
 
@@ -35,7 +39,13 @@ func tagAwsInstance(args TagBlockArgs) (*Result, error) {
 			return nil, err
 		}
 
-		swappedTagsStrings = append(swappedTagsStrings, volumeTagBlock)
+		guardedVolumeTagBlock :=
+			"(" + originalVolumeTags + ") == null ? null : " + volumeTagBlock
+		args.Block.Body().SetAttributeRaw(
+			"volume_tags",
+			ParseHclValueStringToTokens(guardedVolumeTagBlock),
+		)
+		swappedTagsStrings = append(swappedTagsStrings, guardedVolumeTagBlock)
 	} else {
 		rootBlockDevice := args.Block.Body().FirstMatchingBlock("root_block_device", nil)
 		if rootBlockDevice == nil {

--- a/internal/tagging/tagging_test.go
+++ b/internal/tagging/tagging_test.go
@@ -71,33 +71,47 @@ func TestTagBlock_MergeOrder(t *testing.T) {
 	}
 }
 
-func TestTagAwsInstance_PreservesNullableVolumeTags(t *testing.T) {
-	file := hclwrite.NewEmptyFile()
-	resource := file.Body().AppendNewBlock("resource", []string{"aws_instance", "test"})
-	resource.Body().SetAttributeRaw(
-		"volume_tags",
-		ParseHclValueStringToTokens(`var.enable_volume_tags ? { env = "test" } : null`),
-	)
-
-	args := TagBlockArgs{
-		Filename: "main",
-		Block:    resource,
-		Tags:     `{"owner":"terratag"}`,
-		Terratag: common.TerratagLocal{
-			Found: map[string]hclwrite.Tokens{},
-			Added: `{"owner"="terratag"}`,
+func TestTagAwsInstance_VolumeTags(t *testing.T) {
+	testCases := []struct {
+		name     string
+		original string
+		expected string
+	}{
+		{
+			name:     "conditionally-null expression is null-guarded",
+			original: `var.enable_volume_tags ? { env = "test" } : null`,
+			expected: `(var.enable_volume_tags ? { env = "test" } : null) == null ? null : merge( var.enable_volume_tags ? { env = "test" } : null, local.terratag_added_main)`,
 		},
-		TagId: "tags",
+		{
+			name:     "literal map is merged without a guard",
+			original: `{ env = "test" }`,
+			expected: `merge( { "env" = "test" }, local.terratag_added_main)`,
+		},
 	}
 
-	_, err := tagAwsInstance(args)
-	assert.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := hclwrite.NewEmptyFile()
+			resource := file.Body().AppendNewBlock("resource", []string{"aws_instance", "test"})
+			resource.Body().SetAttributeRaw("volume_tags", ParseHclValueStringToTokens(tc.original))
 
-	volumeTags := resource.Body().GetAttribute("volume_tags")
-	assert.NotNil(t, volumeTags)
-	assert.Equal(
-		t,
-		`(var.enable_volume_tags ? { env = "test" } : null) == null ? null : merge( var.enable_volume_tags ? { env = "test" } : null, local.terratag_added_main)`,
-		strings.TrimSpace(string(volumeTags.Expr().BuildTokens(hclwrite.Tokens{}).Bytes())),
-	)
+			args := TagBlockArgs{
+				Filename: "main",
+				Block:    resource,
+				Tags:     `{"owner":"terratag"}`,
+				Terratag: common.TerratagLocal{
+					Found: map[string]hclwrite.Tokens{},
+					Added: `{"owner"="terratag"}`,
+				},
+				TagId: "tags",
+			}
+
+			_, err := tagAwsInstance(args)
+			assert.NoError(t, err)
+
+			volumeTags := resource.Body().GetAttribute("volume_tags")
+			assert.NotNil(t, volumeTags)
+			assert.Equal(t, tc.expected, strings.TrimSpace(string(volumeTags.Expr().BuildTokens(hclwrite.Tokens{}).Bytes())))
+		})
+	}
 }

--- a/internal/tagging/tagging_test.go
+++ b/internal/tagging/tagging_test.go
@@ -1,6 +1,7 @@
 package tagging
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/env0/terratag/internal/common"
@@ -68,4 +69,35 @@ func TestTagBlock_MergeOrder(t *testing.T) {
 			assert.Equal(t, tc.expectedMerge, result, "The merge expression doesn't match expected value")
 		})
 	}
+}
+
+func TestTagAwsInstance_PreservesNullableVolumeTags(t *testing.T) {
+	file := hclwrite.NewEmptyFile()
+	resource := file.Body().AppendNewBlock("resource", []string{"aws_instance", "test"})
+	resource.Body().SetAttributeRaw(
+		"volume_tags",
+		ParseHclValueStringToTokens(`var.enable_volume_tags ? { env = "test" } : null`),
+	)
+
+	args := TagBlockArgs{
+		Filename: "main",
+		Block:    resource,
+		Tags:     `{"owner":"terratag"}`,
+		Terratag: common.TerratagLocal{
+			Found: map[string]hclwrite.Tokens{},
+			Added: `{"owner"="terratag"}`,
+		},
+		TagId: "tags",
+	}
+
+	_, err := tagAwsInstance(args)
+	assert.NoError(t, err)
+
+	volumeTags := resource.Body().GetAttribute("volume_tags")
+	assert.NotNil(t, volumeTags)
+	assert.Equal(
+		t,
+		`(var.enable_volume_tags ? { env = "test" } : null) == null ? null : merge( var.enable_volume_tags ? { env = "test" } : null, local.terratag_added_main)`,
+		strings.TrimSpace(string(volumeTags.Expr().BuildTokens(hclwrite.Tokens{}).Bytes())),
+	)
 }

--- a/test/tests/aws_instance_volume_tags/expected/main.tf
+++ b/test/tests/aws_instance_volume_tags/expected/main.tf
@@ -37,7 +37,9 @@ resource "aws_instance" "volume_tags" {
     device_name = "abcdefg"
   }
 
-  volume_tags = merge({
+  volume_tags = ({
+    c = "d"
+    }) == null ? null : merge({
     "c" = "d"
   }, local.terratag_added_main)
 
@@ -92,6 +94,23 @@ resource "aws_instance" "multiple_tags" {
   root_block_device {
     tags = local.terratag_added_main
   }
+}
+
+resource "aws_instance" "nullable_volume_tags" {
+  ami           = "dasdasD"
+  instance_type = "t3.micro"
+
+  volume_tags = (var.enable_volume_tags ? { env = "test" } : null) == null ? null : merge(var.enable_volume_tags ? { env = "test" } : null, local.terratag_added_main)
+
+  root_block_device {
+    tags = { Name = "test" }
+  }
+  tags = local.terratag_added_main
+}
+
+variable "enable_volume_tags" {
+  type    = bool
+  default = false
 }
 
 locals {

--- a/test/tests/aws_instance_volume_tags/expected/main.tf
+++ b/test/tests/aws_instance_volume_tags/expected/main.tf
@@ -37,9 +37,7 @@ resource "aws_instance" "volume_tags" {
     device_name = "abcdefg"
   }
 
-  volume_tags = ({
-    c = "d"
-    }) == null ? null : merge({
+  volume_tags = merge({
     "c" = "d"
   }, local.terratag_added_main)
 

--- a/test/tests/aws_instance_volume_tags/input/main.tf
+++ b/test/tests/aws_instance_volume_tags/input/main.tf
@@ -81,3 +81,19 @@ resource "aws_instance" "multiple_tags" {
     }
   }
 }
+
+resource "aws_instance" "nullable_volume_tags" {
+  ami           = "dasdasD"
+  instance_type = "t3.micro"
+
+  volume_tags = var.enable_volume_tags ? { env = "test" } : null
+
+  root_block_device {
+    tags = { Name = "test" }
+  }
+}
+
+variable "enable_volume_tags" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
## Summary

Preserve the original nullability of `aws_instance.volume_tags` when Terratag adds volume tags. The generated expression now returns `null` when the original expression evaluates to `null`, avoiding the `root_block_device.tags` conflict while retaining the existing merge behavior for non-null values.

Fixes #241

## Changes

- guard the generated `volume_tags` merge with an original-value null check
- add a focused unit regression test for a conditionally-null expression
- extend the existing `aws_instance_volume_tags` fixture with the reported conditional pattern

## Testing

- `go test ./internal/tagging -run TestTagAwsInstance_PreservesNullableVolumeTags -count=1`
- `SKIP_INTEGRATION_TESTS=1 go test ./...`
- `go vet ./...`
- `go fmt ./...`
- focused `TestTerraformlatest/aws_instance_volume_tags` fixture run with a local provider-schema stub