### PR TITLE
Enable terragrunt v0.88.0+ and v1, maintain legacy support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
   terragrunt-integration-tests:
     name: Terragrunt Integration Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terragrunt_version:
+          - "0.78.0"
+          - "0.95.1"
+          - "latest"
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -97,7 +104,7 @@ jobs:
       - name: Install Terragrunt
         uses: autero1/action-terragrunt@v3
         with:
-          terragrunt-version: 0.77.20
+          terragrunt-version: ${{ matrix.terragrunt_version }}
       - name: Print Terragrunt version
         run: |
           terragrunt --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         terragrunt_version:
+          - "0.77.20"
           - "0.78.0"
           - "0.95.1"
           - "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,23 @@ jobs:
       fail-fast: false
       matrix:
         terragrunt_version:
+          # Below TerragruntRunMinVersion (0.78.0): exercises the legacy
+          # code path, which does not use the 'run' command.
           - "0.77.20"
+          # Exact TerragruntRunMinVersion: the boundary where terratag
+          # switches from the legacy invocation to 'run'.
           - "0.78.0"
+          # First version where terragrunt stopped forwarding unknown
+          # top-level commands (the break reported in #230). Confirms
+          # the 'run' command fix works.
           - "0.88.1"
+          # Later 0.x release, further from the 0.88.0 boundary, to
+          # catch regressions before the 1.x line.
           - "0.95.1"
+          # First stable major release.
           - "1.0.0"
+          # Catches upcoming breaking changes early; non-blocking (see
+          # continue-on-error below) so it can't fail master CI.
           - "latest"
         include:
           - terragrunt_version: "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,19 @@ jobs:
   terragrunt-integration-tests:
     name: Terragrunt Integration Tests
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue_on_error == true }}
     strategy:
       fail-fast: false
       matrix:
         terragrunt_version:
           - "0.77.20"
           - "0.78.0"
+          - "0.88.1"
           - "0.95.1"
           - "latest"
+        include:
+          - terragrunt_version: "latest"
+            continue_on_error: true
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           - "0.78.0"
           - "0.88.1"
           - "0.95.1"
+          - "1.0.0"
           - "latest"
         include:
           - terragrunt_version: "latest"

--- a/README.md
+++ b/README.md
@@ -223,6 +223,27 @@ terratag -tags='{"env":"prod"}' -filter='^aws_' -skip='^aws_iam_'
   - `azurestack`
   - `azapi`
 
+### Usage with Terragrunt
+
+Terratag supports Terragrunt v0.78.0 and above.
+> Note: Terragrunt hasn't released a stable 1.x version yet,
+  so compatibility with future releases isn't guaranteed.
+
+To use terratag with Terragrunt:
+
+- Use `-type=terragrunt` for a standard unit
+- Use `-type=terragrunt-run-all` for implicit stacks
+
+> Note: Explicit stacks are not explicitly supported.
+  If you are working with an explicit stack,
+  you may run terratag on each unit individually by using `-type=terragrunt` and `-dir=<unit_path>`.
+  If your generated stack is similar to an implicit stack,
+  you may use `-type=terragrunt-run-all` from the generated stack directory (`.terragrunt-stack` by default).
+  Remember to initialize the units in the stack by either running `terragrunt stack run init`,
+  or running `terragrunt init` in each unit beforehand.
+
+If issues arise with new Terragrunt versions, please open an issue.
+
 ## Develop
 
 Issues and Pull Requests are very welcome!

--- a/README.md
+++ b/README.md
@@ -225,9 +225,6 @@ terratag -tags='{"env":"prod"}' -filter='^aws_' -skip='^aws_iam_'
 
 ### Usage with Terragrunt
 
-> Note: Terragrunt hasn't released a stable 1.x version yet,
-  so compatibility with future releases isn't guaranteed.
-
 To use terratag with Terragrunt:
 
 - Use `-type=terragrunt` for a standard unit

--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ terratag -tags='{"env":"prod"}' -filter='^aws_' -skip='^aws_iam_'
 
 ### Usage with Terragrunt
 
-Terratag supports Terragrunt v0.78.0 and above.
 > Note: Terragrunt hasn't released a stable 1.x version yet,
   so compatibility with future releases isn't guaranteed.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/hashicorp/go-hclog v1.6.3
+	github.com/hashicorp/go-version v1.8.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
+github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/internal/terraform/version.go
+++ b/internal/terraform/version.go
@@ -1,0 +1,61 @@
+package terraform
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+
+	version "github.com/hashicorp/go-version"
+)
+
+var (
+	terragruntVersionOnce sync.Once
+	terragruntVersion     string
+	terragruntParsed      *version.Version
+	terragruntVersionErr  error
+)
+
+var terragruntVersionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+const TerragruntRunMinVersion = "0.78.0"
+
+func GetTerragruntVersion() (string, error) {
+	terragruntVersionOnce.Do(func() {
+		cmd := exec.Command("terragrunt", "--version")
+		out, err := cmd.Output()
+		if err != nil {
+			terragruntVersionErr = fmt.Errorf("failed to run 'terragrunt version': %w", err)
+			return
+		}
+
+		match := terragruntVersionRegex.FindStringSubmatch(string(out))
+		if len(match) < 1 {
+			terragruntVersionErr = fmt.Errorf("failed to parse terragrunt version from output: %s", strings.TrimSpace(string(out)))
+			return
+		}
+
+		terragruntVersion = match[0]
+		terragruntParsed, terragruntVersionErr = version.NewVersion(terragruntVersion)
+	})
+
+	return terragruntVersion, terragruntVersionErr
+}
+
+func IsTerragruntVersionAtLeast(minVersion string) (bool, error) {
+	if _, err := GetTerragruntVersion(); err != nil {
+		return false, err
+	}
+
+	minVer, err := version.NewVersion(minVersion)
+	if err != nil {
+		return false, fmt.Errorf("invalid min terragrunt version '%s': %w", minVersion, err)
+	}
+
+	return terragruntParsed.GreaterThanOrEqual(minVer), nil
+}
+
+func IsTerragruntRunSupported() (bool, error) {
+	return IsTerragruntVersionAtLeast(TerragruntRunMinVersion)
+}

--- a/internal/terraform/version.go
+++ b/internal/terraform/version.go
@@ -11,51 +11,50 @@ import (
 )
 
 var (
-	terragruntVersionOnce sync.Once
-	terragruntVersion     string
-	terragruntParsed      *version.Version
-	terragruntVersionErr  error
+	terragruntRunSupportedOnce sync.Once
+	terragruntRunSupported     bool
+	terragruntRunSupportedErr  error
 )
 
 var terragruntVersionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
 
 const TerragruntRunMinVersion = "0.78.0"
 
-func GetTerragruntVersion() (string, error) {
-	terragruntVersionOnce.Do(func() {
+// parseTerragruntVersion extracts a semantic version from the output of 'terragrunt --version'.
+func parseTerragruntVersion(out string) (*version.Version, error) {
+	match := terragruntVersionRegex.FindString(out)
+	if match == "" {
+		return nil, fmt.Errorf("failed to parse terragrunt version from output: %s", strings.TrimSpace(out))
+	}
+
+	return version.NewVersion(match)
+}
+
+// IsTerragruntRunSupported reports whether the installed terragrunt version supports the 'run' command.
+func IsTerragruntRunSupported() (bool, error) {
+	terragruntRunSupportedOnce.Do(func() {
 		cmd := exec.Command("terragrunt", "--version")
+
 		out, err := cmd.Output()
 		if err != nil {
-			terragruntVersionErr = fmt.Errorf("failed to run 'terragrunt version': %w", err)
+			terragruntRunSupportedErr = fmt.Errorf("failed to run 'terragrunt --version': %w", err)
 			return
 		}
 
-		match := terragruntVersionRegex.FindStringSubmatch(string(out))
-		if len(match) < 1 {
-			terragruntVersionErr = fmt.Errorf("failed to parse terragrunt version from output: %s", strings.TrimSpace(string(out)))
+		parsed, err := parseTerragruntVersion(string(out))
+		if err != nil {
+			terragruntRunSupportedErr = err
 			return
 		}
 
-		terragruntVersion = match[0]
-		terragruntParsed, terragruntVersionErr = version.NewVersion(terragruntVersion)
+		minVer, err := version.NewVersion(TerragruntRunMinVersion)
+		if err != nil {
+			terragruntRunSupportedErr = fmt.Errorf("invalid min terragrunt version '%s': %w", TerragruntRunMinVersion, err)
+			return
+		}
+
+		terragruntRunSupported = parsed.GreaterThanOrEqual(minVer)
 	})
 
-	return terragruntVersion, terragruntVersionErr
-}
-
-func IsTerragruntVersionAtLeast(minVersion string) (bool, error) {
-	if _, err := GetTerragruntVersion(); err != nil {
-		return false, err
-	}
-
-	minVer, err := version.NewVersion(minVersion)
-	if err != nil {
-		return false, fmt.Errorf("invalid min terragrunt version '%s': %w", minVersion, err)
-	}
-
-	return terragruntParsed.GreaterThanOrEqual(minVer), nil
-}
-
-func IsTerragruntRunSupported() (bool, error) {
-	return IsTerragruntVersionAtLeast(TerragruntRunMinVersion)
+	return terragruntRunSupported, terragruntRunSupportedErr
 }

--- a/internal/terraform/version_test.go
+++ b/internal/terraform/version_test.go
@@ -1,0 +1,50 @@
+package terraform
+
+import "testing"
+
+func TestParseTerragruntVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "standard version output",
+			out:  "terragrunt version v0.77.20",
+			want: "0.77.20",
+		},
+		{
+			name: "prerelease version",
+			out:  "terragrunt version v0.88.0-alpha",
+			want: "0.88.0",
+		},
+		{
+			name:    "garbage input",
+			out:     "command not found: terragrunt",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTerragruntVersion(tt.out)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got none")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got.String() != tt.want {
+				t.Fatalf("got %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/tfschema/tfschema.go
+++ b/internal/tfschema/tfschema.go
@@ -65,13 +65,17 @@ func InitProviderSchemas(dir string, iacType common.IACType, defaultToTerraform 
 
 	log.Print("[INFO] Fetching provider schemas for directory: ", dir)
 
-	var cmd *exec.Cmd
-	if iacType == common.TerragruntRunAll {
-		log.Print("[INFO] Using terragrunt run-all mode")
-		cmd = exec.Command(name, "run-all", "providers", "schema", "-json")
-	} else {
-		cmd = exec.Command(name, "providers", "schema", "-json")
+	cmd := exec.Command(name)
+	if iacType == common.Terragrunt || iacType == common.TerragruntRunAll {
+		cmd.Args = append(cmd.Args, "run")
+		if iacType == common.TerragruntRunAll {
+			log.Print("[INFO] Using terragrunt run-all mode")
+			cmd.Args = append(cmd.Args, "--all")
+		}
+		cmd.Args = append(cmd.Args, "--")
 	}
+
+	cmd.Args = append(cmd.Args, "providers", "schema", "-json")
 	cmd.Dir = dir
 
 	out, err := cmd.Output()

--- a/internal/tfschema/tfschema.go
+++ b/internal/tfschema/tfschema.go
@@ -65,7 +65,7 @@ func InitProviderSchemas(dir string, iacType common.IACType, defaultToTerraform 
 
 		supportsRun, err := terraform.IsTerragruntRunSupported()
 		if err != nil {
-			return err
+			log.Printf("[WARN] Failed to determine terragrunt version, falling back to legacy invocation: %v", err)
 		}
 
 		supportsTerragruntRun = supportsRun
@@ -75,26 +75,28 @@ func InitProviderSchemas(dir string, iacType common.IACType, defaultToTerraform 
 
 	log.Print("[INFO] Fetching provider schemas for directory: ", dir)
 
-	cmd := exec.Command(name)
+	var args []string
 	if isTerragrunt {
 		if supportsTerragruntRun {
 			log.Print("[INFO] Using terragrunt's 'run' command")
-			cmd.Args = append(cmd.Args, "run")
+			args = append(args, "run")
 			if iacType == common.TerragruntRunAll {
 				log.Print("[INFO] Using run with --all flag")
-				cmd.Args = append(cmd.Args, "--all")
+				args = append(args, "--all")
 			}
-			cmd.Args = append(cmd.Args, "--")
+			args = append(args, "--")
 		} else {
 			log.Print("[INFO] Terragrunt does not support 'run' command; using legacy invocation")
 			if iacType == common.TerragruntRunAll {
 				log.Print("[INFO] Using terragrunt run-all")
-				cmd.Args = append(cmd.Args, "run-all")
+				args = append(args, "run-all")
 			}
 		}
 	}
 
-	cmd.Args = append(cmd.Args, "providers", "schema", "-json")
+	args = append(args, "providers", "schema", "-json")
+
+	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 
 	out, err := cmd.Output()
@@ -110,7 +112,7 @@ func InitProviderSchemas(dir string, iacType common.IACType, defaultToTerraform 
 		log.Printf("Standard output: %s\n", string(out))
 		log.Println("===============================================")
 
-		return fmt.Errorf("failed to execute '%s providers schema -json' command in directory '%s': %w", name, dir, err)
+		return fmt.Errorf("failed to execute '%s' command in directory '%s': %w", strings.Join(cmd.Args, " "), dir, err)
 	}
 
 	// Create a new provider schemas object

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bmatcuk/doublestar"
 	"github.com/env0/terratag/cli"
 	"github.com/env0/terratag/internal/common"
+	"github.com/env0/terratag/internal/terraform"
 	. "github.com/onsi/gomega"
 	"github.com/otiai10/copy"
 	"github.com/spf13/viper"
@@ -460,11 +461,25 @@ func run_opentofu(entryDir string, cmd string) error {
 }
 
 func run_terragrunt(entryDir string, cmd string, runAll bool) error {
-	args := []string{"run"}
-	if runAll {
-		args = append(args, "--all")
+	supportsRun, err := terraform.IsTerragruntRunSupported()
+	if err != nil {
+		return err
 	}
-	args = append(args, cmd)
+
+	args := []string{}
+	if supportsRun {
+		args = append(args, "run")
+		if runAll {
+			args = append(args, "--all")
+		}
+		args = append(args, cmd)
+	} else {
+		if runAll {
+			args = append(args, "run-all", cmd)
+		} else {
+			args = append(args, cmd)
+		}
+	}
 
 	return run("terragrunt", entryDir, args...)
 }

--- a/terratag_test.go
+++ b/terratag_test.go
@@ -243,8 +243,10 @@ func itShouldGenerateExpectedTerragruntTerratagFiles(entryDir string, g *GomegaW
 	expectedPattern := entryDir + "/expected/**/*.tf"
 	expectedTerratag, _ := doublestar.Glob(expectedPattern)
 
-	cachePattern := entryDir + "/out/**/.terragrunt-cache"
+	cachePattern := entryDir + "/out/**/unit*/.terragrunt-cache"
 	cacheDirs, _ := doublestar.Glob(cachePattern)
+
+	g.Expect(len(cacheDirs)).To(BeNumerically(">", 0))
 
 	for _, cacheDir := range cacheDirs {
 		hashmap := make(map[string]string)
@@ -458,9 +460,9 @@ func run_opentofu(entryDir string, cmd string) error {
 }
 
 func run_terragrunt(entryDir string, cmd string, runAll bool) error {
-	args := []string{}
+	args := []string{"run"}
 	if runAll {
-		args = append(args, "run-all")
+		args = append(args, "--all")
 	}
 	args = append(args, cmd)
 


### PR DESCRIPTION
Supersedes #236 — same approach, rebased on master with review feedback applied.

## Summary
- Adds support for terragrunt v0.88.0 and up, including v1.0.0+
- Maintains legacy support for terragrunt versions < 0.78.0
- Updates docs for terragrunt support
- Tests against several terragrunt versions in CI

## Changes since #236
- Split version parsing into a pure, unit-tested `parseTerragruntVersion` function
- Fall back to legacy invocation instead of hard-failing when the terragrunt version can't be determined
- Collapsed the version-check API to a single `IsTerragruntRunSupported` helper (the only one with a caller)
- Fixed the error message to reflect the actual command run (`run --all` vs `providers schema`)
- Build args as a slice passed to `exec.Command` instead of mutating `cmd.Args`
- Pinned a `0.88.1` CI leg (the exact version that broke in #230) and made the `latest` leg non-blocking
- Added a `1.0.0` CI leg and removed the README note claiming no stable Terragrunt 1.x exists (it has since been released)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/...` (includes new `TestParseTerragruntVersion` unit test)
- [x] CI: terragrunt integration tests across 0.77.20 / 0.78.0 / 0.88.1 / 0.95.1 / 1.0.0 / latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)